### PR TITLE
✨feat: S3 File upload 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	implementation 'com.sun.mail:jakarta.mail:2.0.1'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation(platform("software.amazon.awssdk:bom:2.27.21"))
+	implementation("software.amazon.awssdk:s3")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/club_board/club_board_server/config/JpaConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.club_board.club_board_server.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
@@ -1,0 +1,38 @@
+package com.club_board.club_board_server.controller.file;
+
+import com.club_board.club_board_server.dto.file.request.PresignedUploadUrlRequest;
+import com.club_board.club_board_server.dto.file.response.PresignedDownloadUrlResponse;
+import com.club_board.club_board_server.dto.file.response.PresignedUploadUrlResponse;
+import com.club_board.club_board_server.response.ResponseBody;
+import com.club_board.club_board_server.response.ResponseUtil;
+import com.club_board.club_board_server.service.file.S3Service;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/files")
+public class FileController {
+    private final S3Service s3Service;
+
+    @PostMapping("/upload-url")
+    public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generateUploadUrl(
+            @RequestBody @Valid PresignedUploadUrlRequest request
+    ) {
+        Long userId = 1L;
+        PresignedUploadUrlResponse response = s3Service.generateUploadUrl(request, userId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ResponseUtil.createSuccessResponse(response));
+    }
+
+    @GetMapping("/download-url")
+    public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generateDownloadUrl(@RequestParam Long fileId) {
+        PresignedDownloadUrlResponse response = s3Service.generateDownloadUrl(fileId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
+    }
+
+}

--- a/src/main/java/com/club_board/club_board_server/domain/AuditEntity.java
+++ b/src/main/java/com/club_board/club_board_server/domain/AuditEntity.java
@@ -1,0 +1,25 @@
+package com.club_board.club_board_server.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class AuditEntity {
+    @CreatedDate
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "updated_date", nullable = false)
+    private LocalDateTime updateDate;
+}

--- a/src/main/java/com/club_board/club_board_server/domain/file/File.java
+++ b/src/main/java/com/club_board/club_board_server/domain/file/File.java
@@ -1,0 +1,22 @@
+package com.club_board.club_board_server.domain.file;
+
+import com.club_board.club_board_server.domain.post.Post;
+import jakarta.persistence.*;
+
+@Entity
+public class File {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "file_id")
+    private Long id;
+
+    @Column(name = "file_name", unique = true)
+    private String fileName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    public File(String fileName) {
+        this.fileName = fileName;
+    }
+}

--- a/src/main/java/com/club_board/club_board_server/domain/file/File.java
+++ b/src/main/java/com/club_board/club_board_server/domain/file/File.java
@@ -2,7 +2,9 @@ package com.club_board.club_board_server.domain.file;
 
 import com.club_board.club_board_server.domain.post.Post;
 import jakarta.persistence.*;
+import lombok.Getter;
 
+@Getter
 @Entity
 public class File {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/club_board/club_board_server/domain/post/Post.java
+++ b/src/main/java/com/club_board/club_board_server/domain/post/Post.java
@@ -1,0 +1,28 @@
+package com.club_board.club_board_server.domain.post;
+
+import com.club_board.club_board_server.domain.AuditEntity;
+import com.club_board.club_board_server.domain.User;
+import com.club_board.club_board_server.domain.file.File;
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+public class Post extends AuditEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @Column(name = "post_title")
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User author;
+
+    @OneToMany
+    @Column(name = "post_file_names")
+    private List<File> fileNames;
+}

--- a/src/main/java/com/club_board/club_board_server/dto/file/request/PresignedUploadUrlRequest.java
+++ b/src/main/java/com/club_board/club_board_server/dto/file/request/PresignedUploadUrlRequest.java
@@ -1,0 +1,13 @@
+package com.club_board.club_board_server.dto.file.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class PresignedUploadUrlRequest {
+    @NotBlank
+    private String fileName;
+    @NotBlank
+    private String contentType;
+}

--- a/src/main/java/com/club_board/club_board_server/dto/file/request/PresignedUploadUrlRequest.java
+++ b/src/main/java/com/club_board/club_board_server/dto/file/request/PresignedUploadUrlRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter @Setter
+@Getter
 public class PresignedUploadUrlRequest {
     @NotBlank
     private String fileName;

--- a/src/main/java/com/club_board/club_board_server/dto/file/response/PresignedUploadUrlResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/file/response/PresignedUploadUrlResponse.java
@@ -1,0 +1,18 @@
+package com.club_board.club_board_server.dto.file.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter @Setter
+@Builder
+public class PresignedUploadUrlResponse {
+    private String url;
+
+    @Builder.Default
+    private String method = "PUT";
+
+    private Map<String, String> headers;
+}

--- a/src/main/java/com/club_board/club_board_server/dto/file/response/PresignedUploadUrlResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/file/response/PresignedUploadUrlResponse.java
@@ -14,5 +14,7 @@ public class PresignedUploadUrlResponse {
     @Builder.Default
     private String method = "PUT";
 
+    private Long fileId;
+
     private Map<String, String> headers;
 }

--- a/src/main/java/com/club_board/club_board_server/repository/file/FileRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/file/FileRepository.java
@@ -1,0 +1,8 @@
+package com.club_board.club_board_server.repository.file;
+
+import com.club_board.club_board_server.domain.file.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+
+}

--- a/src/main/java/com/club_board/club_board_server/service/file/FileService.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/FileService.java
@@ -1,0 +1,18 @@
+package com.club_board.club_board_server.service.file;
+
+import com.club_board.club_board_server.domain.file.File;
+import com.club_board.club_board_server.repository.file.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class FileService {
+    private final FileRepository fileRepository;
+
+    @Transactional
+    public File saveFileName(String objectName) {
+        return fileRepository.save(new File(objectName));
+    }
+}

--- a/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
@@ -1,0 +1,75 @@
+package com.club_board.club_board_server.service.file;
+
+
+import com.club_board.club_board_server.dto.file.request.PresignedUploadUrlRequest;
+import com.club_board.club_board_server.dto.file.response.PresignedDownloadUrlResponse;
+import com.club_board.club_board_server.dto.file.response.PresignedUploadUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+    private final FileService fileService;
+
+    @Value("${aws.s3.credentials.accessKey}")
+    private String accessKey;
+    @Value("${aws.s3.credentials.secretKey}")
+    private String secretKey;
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    public PresignedUploadUrlResponse generateUploadUrl(PresignedUploadUrlRequest request, Long userId) {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        S3Presigner s3Presigner = S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+
+        String objectName = this.generateFileName(request.getFileName(), userId);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectName)
+                .build();
+
+        PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(60))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
+
+        fileService.saveFileName(objectName);
+
+        s3Presigner.close();
+
+        return PresignedUploadUrlResponse.builder()
+                .url(presignedPutObjectRequest.url().toString())
+                .build();
+    }
+
+    public PresignedDownloadUrlResponse generateDownloadUrl(Long fileId) {
+        // TODO. 구현 필요
+        return null;
+    }
+
+    private String generateFileName(String originFileName, Long userId) {
+        return String.join(
+                "/", userId.toString(), UUID.randomUUID().toString(), originFileName
+        );
+    }
+
+}

--- a/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
@@ -1,6 +1,7 @@
 package com.club_board.club_board_server.service.file;
 
 
+import com.club_board.club_board_server.domain.file.File;
 import com.club_board.club_board_server.dto.file.request.PresignedUploadUrlRequest;
 import com.club_board.club_board_server.dto.file.response.PresignedDownloadUrlResponse;
 import com.club_board.club_board_server.dto.file.response.PresignedUploadUrlResponse;
@@ -52,12 +53,13 @@ public class S3Service {
 
         PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
 
-        fileService.saveFileName(objectName);
+        File savedFile = fileService.saveFileName(objectName);
 
         s3Presigner.close();
 
         return PresignedUploadUrlResponse.builder()
                 .url(presignedPutObjectRequest.url().toString())
+                .fileId(savedFile.getId())
                 .build();
     }
 


### PR DESCRIPTION
## ✨ PR 요약
- 생성 및 수정 시간 DB 저장을 위한 공통 추상 클래스 추가
- presigned-url을 통한 AWS의 S3 파일 업로드 구현

## 🔎 작업 상세
- AuditEntity를 상속 받아 엔티티를 정의하면 생성 시간과 수정 시간이 자동으로 저장될 수 있도록 하였음
  - 자동 저장을 위한 JpaConfig 파일 추가
- 파일명과 Content-Type를 받아 파일 업로드를 할 수 있는 presigned-url을 발급받는 api 추가

## 📃 TODO
- 파일 다운로드 로직 추가
- 보안을 위해 S3 추가 설정 및 필요하다면 로직도 수정
- 유저의 id, UUID, 파일명을 조합한 이름으로 업로드하므로 객체 이름이 겹칠 일은 없다고 보면 되나,
   아예 불가능한 일은 아니므로 해당 사항을 확인하거나 예외 처리할 수 있는 로직 추가
