### PR TITLE
:sparkles:feat: presigned-url을 활용한 파일 다운로드 추가

### DIFF
--- a/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +21,7 @@ public class FileController {
     private final S3Service s3Service;
 
     @PostMapping("/upload-url")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generateUploadUrl(
             @RequestBody @Valid PresignedUploadUrlRequest request
     ) {
@@ -32,6 +34,22 @@ public class FileController {
     @GetMapping("/download-url")
     public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generateDownloadUrl(@RequestParam Long fileId) {
         PresignedDownloadUrlResponse response = s3Service.generateDownloadUrl(fileId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
+    }
+
+    @PostMapping("/bookImage/upload-url")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generateBookImageUploadUrl(
+            @RequestBody @Valid PresignedUploadUrlRequest request
+    ) {
+        PresignedUploadUrlResponse response = s3Service.generateBookImageUploadUrl(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ResponseUtil.createSuccessResponse(response));
+    }
+
+    @GetMapping("/bookImage/download-url")
+    public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generateBookImageDownloadUrl(@RequestParam Long bookImageId) {
+        PresignedDownloadUrlResponse response = s3Service.generateBookImageDownloadUrl(bookImageId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }
 

--- a/src/main/java/com/club_board/club_board_server/domain/file/File.java
+++ b/src/main/java/com/club_board/club_board_server/domain/file/File.java
@@ -3,22 +3,31 @@ package com.club_board.club_board_server.domain.file;
 import com.club_board.club_board_server.domain.post.Post;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
+@NoArgsConstructor
 public class File {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "file_id")
     private Long id;
 
-    @Column(name = "file_name", unique = true)
-    private String fileName;
+    @Column(name = "url", unique = true, nullable = false)
+    private String url;
 
+    @Setter
+    @Column(name = "is_main", nullable = false)
+    private Boolean isMain;
+
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    public File(String fileName) {
-        this.fileName = fileName;
+    public File(String fileUrl) {
+        this.url = fileUrl;
+        this.isMain = false;
     }
 }

--- a/src/main/java/com/club_board/club_board_server/dto/file/response/PresignedDownloadUrlResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/file/response/PresignedDownloadUrlResponse.java
@@ -1,10 +1,14 @@
 package com.club_board.club_board_server.dto.file.response;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
+@Builder
 public class PresignedDownloadUrlResponse {
     private String url;
-    private String method;
+
+    @Builder.Default
+    private String method = "GET";
 }

--- a/src/main/java/com/club_board/club_board_server/repository/book/BookImageRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/book/BookImageRepository.java
@@ -1,0 +1,9 @@
+package com.club_board.club_board_server.repository.book;
+
+import com.club_board.club_board_server.domain.book.BookImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookImageRepository extends JpaRepository<BookImage, Long> {
+}

--- a/src/main/java/com/club_board/club_board_server/repository/book/BookRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/book/BookRepository.java
@@ -1,0 +1,9 @@
+package com.club_board.club_board_server.repository.book;
+
+import com.club_board.club_board_server.domain.book.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/com/club_board/club_board_server/repository/file/FileRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/file/FileRepository.java
@@ -2,7 +2,9 @@ package com.club_board.club_board_server.repository.file;
 
 import com.club_board.club_board_server.domain.file.File;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface FileRepository extends JpaRepository<File, Long> {
 
 }

--- a/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
@@ -32,6 +32,11 @@ public enum ExceptionType {
     INVALID_ACCESS_TOKEN(UNAUTHORIZED,"A005","Access Token 이 유효하지 않습니다."),
     NOT_FOUND_ACCESS_TOKEN(UNAUTHORIZED,"A006","Access Token 이 존재하지 않습니다."),
     INVALID_REFRESH_TOKEN(UNAUTHORIZED,"A007","Refresh Token 만료"),
+
+    // File
+    FILE_NOT_FOUND(NOT_FOUND, "F001", "파일이 존재하지 않습니다."),
+    INVALID_FILE_TYPE(BAD_REQUEST, "F002", "허용되지 않은 파일 타입입니다. (image만 가능)"),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/club_board/club_board_server/service/book/BookImageService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookImageService.java
@@ -1,0 +1,26 @@
+package com.club_board.club_board_server.service.book;
+
+import com.club_board.club_board_server.domain.book.BookImage;
+import com.club_board.club_board_server.repository.book.BookImageRepository;
+import com.club_board.club_board_server.response.exception.BusinessException;
+import com.club_board.club_board_server.response.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class BookImageService {
+    private final BookImageRepository bookImageRepository;
+
+    @Transactional
+    public BookImage saveBookImage(String objectName) {
+        return bookImageRepository.save(new BookImage(objectName));
+    }
+
+    public String getFileName(Long bookImageId) {
+        return bookImageRepository.findById(bookImageId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.FILE_NOT_FOUND))
+                .getUrl();
+    }
+}

--- a/src/main/java/com/club_board/club_board_server/service/file/FileService.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/FileService.java
@@ -2,6 +2,8 @@ package com.club_board.club_board_server.service.file;
 
 import com.club_board.club_board_server.domain.file.File;
 import com.club_board.club_board_server.repository.file.FileRepository;
+import com.club_board.club_board_server.response.exception.BusinessException;
+import com.club_board.club_board_server.response.exception.ExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,5 +16,11 @@ public class FileService {
     @Transactional
     public File saveFileName(String objectName) {
         return fileRepository.save(new File(objectName));
+    }
+
+    public String getFileName(Long fileId) {
+        return fileRepository.findById(fileId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.FILE_NOT_FOUND))
+                .getUrl();
     }
 }

--- a/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
@@ -1,18 +1,25 @@
 package com.club_board.club_board_server.service.file;
 
 
+import com.club_board.club_board_server.domain.book.BookImage;
 import com.club_board.club_board_server.domain.file.File;
 import com.club_board.club_board_server.dto.file.request.PresignedUploadUrlRequest;
 import com.club_board.club_board_server.dto.file.response.PresignedDownloadUrlResponse;
 import com.club_board.club_board_server.dto.file.response.PresignedUploadUrlResponse;
+import com.club_board.club_board_server.response.exception.BusinessException;
+import com.club_board.club_board_server.response.exception.ExceptionType;
+import com.club_board.club_board_server.service.book.BookImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -23,55 +30,155 @@ import java.util.UUID;
 @Service
 public class S3Service {
     private final FileService fileService;
+    private final BookImageService bookImageService;
 
     @Value("${aws.s3.credentials.accessKey}")
     private String accessKey;
+
     @Value("${aws.s3.credentials.secretKey}")
     private String secretKey;
+
     @Value("${aws.s3.bucket}")
     private String bucket;
 
     public PresignedUploadUrlResponse generateUploadUrl(PresignedUploadUrlRequest request, Long userId) {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
-        S3Presigner s3Presigner = S3Presigner.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                .region(Region.AP_NORTHEAST_2)
-                .build();
+        try (
+                S3Presigner s3Presigner = S3Presigner.builder()
+                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                        .region(Region.AP_NORTHEAST_2)
+                        .build()
+        ) {
+            String objectName = this.generateFileName(request.getFileName(), userId);
 
-        String objectName = this.generateFileName(request.getFileName(), userId);
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectName)
+                    .contentType(request.getContentType())
+                    .build();
 
-        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(objectName)
-                .build();
+            PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(60))
+                    .putObjectRequest(putObjectRequest)
+                    .build();
 
-        PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(60))
-                .putObjectRequest(putObjectRequest)
-                .build();
+            PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
 
-        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
+            File savedFile = fileService.saveFileName(objectName);
 
-        File savedFile = fileService.saveFileName(objectName);
-
-        s3Presigner.close();
-
-        return PresignedUploadUrlResponse.builder()
-                .url(presignedPutObjectRequest.url().toString())
-                .fileId(savedFile.getId())
-                .build();
-    }
-
-    public PresignedDownloadUrlResponse generateDownloadUrl(Long fileId) {
-        // TODO. 구현 필요
-        return null;
+            return PresignedUploadUrlResponse.builder()
+                    .url(presignedPutObjectRequest.url().toString())
+                    .fileId(savedFile.getId())
+                    .build();
+        }
     }
 
     private String generateFileName(String originFileName, Long userId) {
         return String.join(
-                "/", userId.toString(), UUID.randomUUID().toString(), originFileName
+                "/", "postFiles", userId.toString(), UUID.randomUUID().toString(), originFileName
         );
     }
 
+    public PresignedDownloadUrlResponse generateDownloadUrl(Long fileId) {
+        String objectName = fileService.getFileName(fileId);
+
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        try (
+                S3Presigner s3Presigner = S3Presigner.builder()
+                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                        .region(Region.AP_NORTHEAST_2)
+                        .build()
+        ) {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectName)
+                    .build();
+
+            GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(60))
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
+
+            return PresignedDownloadUrlResponse.builder()
+                    .url(presignedGetObjectRequest.url().toString())
+                    .build();
+        }
+    }
+
+    public PresignedUploadUrlResponse generateBookImageUploadUrl(PresignedUploadUrlRequest request) {
+        if (!request.getContentType().startsWith("image/")) {
+            throw new BusinessException(ExceptionType.INVALID_FILE_TYPE);
+        }
+
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        try (
+                S3Presigner s3Presigner = S3Presigner.builder()
+                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                        .region(Region.AP_NORTHEAST_2)
+                        .build()
+        ) {
+            String objectName = this.generateBookImageName(request.getFileName());
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectName)
+                    .contentType(request.getContentType())
+                    .build();
+
+            PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(60))
+                    .putObjectRequest(putObjectRequest)
+                    .build();
+
+            PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
+
+            BookImage savedBookImage = bookImageService.saveBookImage(objectName);
+
+            return PresignedUploadUrlResponse.builder()
+                    .url(presignedPutObjectRequest.url().toString())
+                    .fileId(savedBookImage.getId())
+                    .build();
+        }
+    }
+
+    private String generateBookImageName(String originFileName) {
+        return String.join(
+                "/", "bookImages", UUID.randomUUID().toString(), originFileName
+        );
+    }
+
+    public PresignedDownloadUrlResponse generateBookImageDownloadUrl(Long bookImageId) {
+        String objectName = bookImageService.getFileName(bookImageId);
+
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        try (
+                S3Presigner s3Presigner = S3Presigner.builder()
+                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                        .region(Region.AP_NORTHEAST_2)
+                        .build()
+        ) {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectName)
+                    .build();
+
+            GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(60))
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
+
+            return PresignedDownloadUrlResponse.builder()
+                    .url(presignedGetObjectRequest.url().toString())
+                    .build();
+        }
+
+    }
 }


### PR DESCRIPTION
## ✨ PR 요약

- 기존 S3 presigned-url 파일 업로드 수정
- S3 presigned-url 파일 다운로드 추가
- 도서 이미지에 대해 업로드 및 다운로드 로직 기존 게시글 파일 업로드 및 다운로드 로직과 분리


## 🔎 작업 상세
#### ♻️ 변경 사항
- `try-with-resources`를 사용하여 `S3Presigner`의 `close`가 자동으로 되도록 변경
- 파일 이름 생성에 접두어 추가(`postFile`, `bookImage`)
- File 엔티티 필드 이름 변경(`fileName`->`url`) 및 필드 추가(`isMain`) 

#### ✨ 추가 사항
- 다운로드 url 생성 구현
- 도서 이미지에 대해 업로드, 다운로드 url 제공 로직 분리
  - 도서 이미지는 `content-Type`을 image로 제한

## 🗒️참고 사항
- 추후 도서 조회 api 구현 작업 시, `S3Service` 클래스의 `generateBookImageDownloadUrl` 함수(* 필요 인자는 bookImageId)를 호출하여 url을 받아 반환 값에 추가해주시면 됩니다. 😀 (bookImageId도 혹시 모르니 같이 보내는 주면 좋을 것 같습니다)