### PR TITLE
예약 추가 시 동시성 문제 & 예약 취소 시 조건 수정

### DIFF
--- a/src/main/java/com/club_board/club_board_server/controller/auth/AuthController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/auth/AuthController.java
@@ -31,11 +31,5 @@ public class AuthController {
         authService.forgotPassword(resetPasswordRequest);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse("임시 비밀번호 생성 완료"));
     }
-
-    @GetMapping("/board")
-    @PreAuthorize("hasAuthority('ROLE_USER')")
-    public ResponseEntity<ResponseBody<String>> test(){
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse("ok"));
-    }
 }
 

--- a/src/main/java/com/club_board/club_board_server/repository/book/BookRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/book/BookRepository.java
@@ -1,9 +1,19 @@
 package com.club_board.club_board_server.repository.book;
 
 import com.club_board.club_board_server.domain.book.Book;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    @Query("SELECT b FROM Book b WHERE b.id=:bookId")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Book> findBookWithPessimisticLock(@Param("bookId") Long bookId);
 }

--- a/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
@@ -43,7 +43,8 @@ public enum ExceptionType {
     //BOOK
     BOOK_NOT_FOUND(NOT_FOUND,"B001","해당하는 책이 존재하지 않습니다."),
     BOOK_ALREADY_FULL(BAD_REQUEST,"B002","이미 가득 찬 예약입니다."),
-    RESERVATION_NOT_FOUND(NOT_FOUND,"B003","해당하는 예약이 존재하지 않습니다.")
+    RESERVATION_NOT_FOUND(NOT_FOUND,"B003","해당하는 예약이 존재하지 않습니다."),
+    CONCURRENCY_CONFLICT(CONFLICT,"B004","동시에 요청이 처리되어 충돌이 발생했습니다.");
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
@@ -44,7 +44,8 @@ public enum ExceptionType {
     BOOK_NOT_FOUND(NOT_FOUND,"B001","해당하는 책이 존재하지 않습니다."),
     BOOK_ALREADY_FULL(BAD_REQUEST,"B002","이미 가득 찬 예약입니다."),
     RESERVATION_NOT_FOUND(NOT_FOUND,"B003","해당하는 예약이 존재하지 않습니다."),
-    CONCURRENCY_CONFLICT(CONFLICT,"B004","동시에 요청이 처리되어 충돌이 발생했습니다.");
+    CONCURRENCY_CONFLICT(CONFLICT,"B004","동시에 요청이 처리되어 충돌이 발생했습니다."),
+    LOCK_TIMEOUT(CONFLICT,"B005","락 대기 시간이 초과되었습니다.");
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
@@ -41,5 +41,11 @@ public class GlobalExceptionHandler {
                 .status(ExceptionType.CONCURRENCY_CONFLICT.getStatus())
                 .body(ResponseUtil.createFailureResponse(ExceptionType.CONCURRENCY_CONFLICT));
     }
+    @ExceptionHandler(LockTimeoutException.class)
+    public ResponseEntity<ResponseBody<Void>> handleLockTimeoutException(LockTimeoutException e) {
+        return ResponseEntity
+                .status(ExceptionType.LOCK_TIMEOUT.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.LOCK_TIMEOUT));
+    }
 
 }

--- a/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.club_board.club_board_server.response.exception;
 import com.club_board.club_board_server.response.ResponseBody;
 import com.club_board.club_board_server.response.ResponseUtil;
+import jakarta.persistence.LockTimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -30,9 +31,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseBody<Void>> exception(Exception e){
-        e.printStackTrace();
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ResponseUtil.createFailureResponse(ExceptionType.UNEXPECTED_SERVER_ERROR));
     }
+    @ExceptionHandler(LockTimeoutException.class)
+    public ResponseEntity<ResponseBody<Void>> handleLockTimeout(LockTimeoutException e) {
+        return ResponseEntity
+                .status(ExceptionType.CONCURRENCY_CONFLICT.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.CONCURRENCY_CONFLICT));
+    }
+
 }

--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -111,7 +111,7 @@ public class BookService {
                 .orElseThrow(()->new BusinessException(ExceptionType.RESERVATION_NOT_FOUND));
         reservationRepository.delete(reservation);
 
-        if (book.getStatus() == BookStatus.FULLY_RESERVED) {
+        if (book.getStatus() == BookStatus.FULLY_RESERVED && reservationRepository.countActiveReservation(book.getId())-1<3) {
             book.setStatus(BookStatus.AVAILABLE);
             bookRepository.save(book);
         }

--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -72,11 +72,11 @@ public class BookService {
                 .build();
     }
 
-
+    @Transactional
     public void addReservation(Long bookId,Long userId){
 
         // 예약하고자 하는 책 찾기
-        Book book=bookRepository.findById(bookId)
+        Book book=bookRepository.findBookWithPessimisticLock(bookId)
                 .orElseThrow(()->new BusinessException(ExceptionType.BOOK_NOT_FOUND));
 
         // 예약 수를 동적으로 계산하여 체크


### PR DESCRIPTION

## ✨ PR 요약

- 예약 시 동시성 문제 해결
- 예약 취소 조건 수정
- 기존 테스트로 남긴 메서드 삭제

## 🔎 작업 상세
- @Lock(LockModeType.PESSIMISTIC_WRITE)을 통해 ,책 조회 시 비관적 락을 걸어 동시성 문제를 방지하고자 하였습니다.
- 데드락, 락 대기 시간 초과 시 에러 코드와 ExceptionHandler를 추가하였습니다.
- 예약 취소 후에 3명 미만이 되는 경우, 다시 책 이용 가능 상태를 available로 변경합니다. 예약 인원이 3명 이상이면 여전히 FULLY_RESERVED 상태를 유지해야 하지만, 사용자가 예약 취소 후에 책 상태가 FULLY_RESERVED 이고 예약 인원이 3명 미만인 경우 AVAILABLE로 변경을 하도록 했습니다. 

