### PR TITLE
성공 시 반환타입 수정 + 기타 리팩토링

### DIFF
--- a/src/main/java/com/club_board/club_board_server/dto/book/BookResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/book/BookResponse.java
@@ -12,10 +12,11 @@ public class BookResponse {
     private String publisher;
     private BookStatus status;
     private String bookUrl;
+    private int borrowCount;
 
 
     @Builder
-    public BookResponse(Long id,String title, String author, int publishYear, String publisher, BookStatus status, String bookUrl) {
+    public BookResponse(Long id,String title, String author, int publishYear, String publisher, BookStatus status, String bookUrl,int borrowCount) {
         this.id = id;
         this.title = title;
         this.author = author;
@@ -23,5 +24,6 @@ public class BookResponse {
         this.publisher = publisher;
         this.status = status;
         this.bookUrl = bookUrl;
+        this.borrowCount=borrowCount;
     }
 }

--- a/src/main/java/com/club_board/club_board_server/response/ResponseBody.java
+++ b/src/main/java/com/club_board/club_board_server/response/ResponseBody.java
@@ -1,4 +1,6 @@
 package com.club_board.club_board_server.response;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Getter;
@@ -15,5 +17,6 @@ import lombok.Setter;
 })
 
 public sealed  abstract class ResponseBody<T> permits SuccessResponseBody, FailedResponseBody{
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String code;
 }

--- a/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.club_board.club_board_server.response.exception;
 import com.club_board.club_board_server.response.ResponseBody;
 import com.club_board.club_board_server.response.ResponseUtil;
 import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -35,7 +36,7 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ResponseUtil.createFailureResponse(ExceptionType.UNEXPECTED_SERVER_ERROR));
     }
-    @ExceptionHandler(LockTimeoutException.class)
+    @ExceptionHandler(PessimisticLockException.class)
     public ResponseEntity<ResponseBody<Void>> handleLockTimeout(LockTimeoutException e) {
         return ResponseEntity
                 .status(ExceptionType.CONCURRENCY_CONFLICT.getStatus())

--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -39,6 +39,7 @@ public class BookService {
                             if(book.getBookImage()!=null){
                                 bookUrl=s3Service.generateBookImageDownloadUrl(book.getBookImage().getId()).getUrl();
                             }
+                            int borrowCount=reservationRepository.countActiveReservation(book.getId());
 
                 return   BookResponse.builder()
                         .id(book.getId())
@@ -48,6 +49,7 @@ public class BookService {
                         .publisher(book.getPublisher())
                         .status(book.getStatus())
                         .bookUrl(bookUrl)
+                        .borrowCount(borrowCount)
                         .build();
                 })
                 .collect(Collectors.toList());
@@ -61,6 +63,7 @@ public class BookService {
         if(book.getBookImage()!=null){
             bookUrl=s3Service.generateBookImageDownloadUrl(book.getBookImage().getId()).getUrl();
         }
+        int borrowCount=reservationRepository.countActiveReservation(book.getId());
         return BookResponse.builder()
                 .id(book.getId())
                 .author(book.getAuthor())
@@ -69,6 +72,7 @@ public class BookService {
                 .publisher(book.getPublisher())
                 .status(book.getStatus())
                 .bookUrl(bookUrl)
+                .borrowCount(borrowCount)
                 .build();
     }
 
@@ -118,6 +122,8 @@ public class BookService {
     }
 
     // 자정이 될 때마다 스케줄러를 통해 주기적으로 메서드 실행
+    //TODO
+    // Batch Update 적용 고려
     @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
     public void checkUserIsOverdue(){

--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -103,6 +103,7 @@ public class BookService {
     }
 
     // 예약 취소
+    @Transactional
     public void cancelReservation(Long bookId,Long userId){
         Book book=bookRepository.findById(bookId)
                 .orElseThrow(()->new BusinessException(ExceptionType.BOOK_NOT_FOUND));
@@ -113,7 +114,6 @@ public class BookService {
 
         if (book.getStatus() == BookStatus.FULLY_RESERVED && reservationRepository.countActiveReservation(book.getId())-1<3) {
             book.setStatus(BookStatus.AVAILABLE);
-            bookRepository.save(book);
         }
     }
 


### PR DESCRIPTION

## ✨ PR 요약

- GlobalExceptionHandler 수정
- 성공 시 code 반환 삭제
- 예약 취소 @transactional 추가
- 예약 인원 반환

## 🔎 작업 상세

- 기존에는 성공 return에도 code : null 이 포함되었습니다. 성공 시는 별도의 에러코드를 return할 필요성이 없다고 느껴져서 code 부분을 삭제했습니다.
- 기존 GlobalExceptionHandler를 보니 2개의 LockTimeOutException을 처리해주는 부분이 있어서 PessimisticLockException으로 수정했습니다. 
- 예약 취소 시 save 로직을 빼고 @transcational을 추가하였습니다
- 책 조회 response에 예약인원 추가했습니다 

## 스크린샷
![image](https://github.com/user-attachments/assets/8fc9dc92-0d1c-4819-a702-1d3c42aaa2d2)

