### PR TITLE
Access Token, Refresh Token 리팩토링

### DIFF
--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
@@ -31,13 +31,15 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = getAccessToken(request);
+        // 토큰이 존재할 때
         if (accessToken != null) {
-            boolean isValid = tokenProvider.validToken(accessToken);
-            if (isValid) {
-                authenticateWithToken(accessToken);
-            } else {
-                throw new BusinessException(ExceptionType.INVALID_ACCESS_TOKEN);
-            }
+            // 토큰 유효성 검사
+            tokenProvider.validToken(accessToken,TokenType.ACCESS);
+            authenticateWithToken(accessToken);
+        }
+        else{
+            // 토큰이 존재하지 않으면 예외 처리
+            throw new BusinessException(ExceptionType.NOT_FOUND_ACCESS_TOKEN);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
@@ -37,10 +37,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             tokenProvider.validToken(accessToken,TokenType.ACCESS);
             authenticateWithToken(accessToken);
         }
-        else{
-            // 토큰이 존재하지 않으면 예외 처리
-            throw new BusinessException(ExceptionType.NOT_FOUND_ACCESS_TOKEN);
-        }
         filterChain.doFilter(request, response);
     }
 
@@ -66,4 +62,5 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         }
         return null;
     }
+
 }

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenExceptionHandlerFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenExceptionHandlerFilter.java
@@ -1,0 +1,48 @@
+package com.club_board.club_board_server.config.jwt;
+import com.club_board.club_board_server.response.ResponseBody;
+import com.club_board.club_board_server.response.ResponseUtil;
+import com.club_board.club_board_server.response.exception.BusinessException;
+import com.club_board.club_board_server.response.exception.ExceptionType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+
+@Component
+public class TokenExceptionHandlerFilter extends OncePerRequestFilter { // OncePerRequestFilter : 한 요청당 필터가 딱 한 번만 실행되도록 보장하는 추상 클래스
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try{
+            filterChain.doFilter(request, response);
+
+        }catch(BusinessException e){
+            handleBusinessException(request,response,e);
+        }
+
+    }
+    private void handleBusinessException(HttpServletRequest request, HttpServletResponse response, BusinessException e) throws IOException {
+        ExceptionType exceptionType = e.getExceptionType();
+        response.setStatus(exceptionType.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8"); // HttpServletResponse: ISO-8859-1 인코딩 사용하기 때문에 한글 출력을 위해 UTF-8 설정
+        ResponseBody<Void> body= ResponseUtil.createFailureResponse(exceptionType);
+        writeErrorResponse(response,body);
+    }
+    private void writeErrorResponse(HttpServletResponse response, ResponseBody<Void> body) throws IOException{
+        ObjectMapper objectMapper = new ObjectMapper(); // Jackson ObjectMapper 인스턴스 생성
+        String json = objectMapper.writeValueAsString(body);  // ResponseBody 객체를 JSON 문자열로 직렬화
+
+        try (PrintWriter writer = response.getWriter()) { // PrintWriter 자원을 안전하게 닫기 위해 try-with-resource 사용
+            writer.write(json);
+            writer.flush();
+        }
+    }
+}

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenProvider.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenProvider.java
@@ -1,12 +1,10 @@
 package com.club_board.club_board_server.config.jwt;
+import com.club_board.club_board_server.domain.RefreshToken;
 import com.club_board.club_board_server.domain.user.User;
 import com.club_board.club_board_server.repository.refreshToken.RefreshTokenRepository;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Header;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,7 +43,6 @@ public class TokenProvider {
             List<String> authorities = List.of("ROLE_" + user.getRole());
             // JWT 발급 시간
             Date now=new Date();
-            log.info("만료 시간: {}", expiry);
             return Jwts.builder()
                     .setHeaderParam(Header.TYPE,Header.JWT_TYPE)  //헤더 타입
                     .setIssuer(jwtProperties.getIssuer())    //발급자
@@ -63,9 +60,8 @@ public class TokenProvider {
         }
     }
 
-    public boolean validToken(String token) {
+    public void validToken(String token,TokenType tokenType) {
         try {
-            log.info("token={}", token);
 
             // SecretKeySpec을 사용하여 Key 객체 생성
             String base64SecretKey = jwtProperties.getSecretKey();
@@ -76,14 +72,21 @@ public class TokenProvider {
             Claims claims = Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
-                    .parseClaimsJws(token)
+                    .parseClaimsJws(token)// 토큰의 만료, 서명 오류, 구조적 문제 검사
                     .getBody();
-
-            log.info("Token is valid. Claims: {}", claims);
-            return true;
-        } catch (Exception e) {
-            log.error("Invalid token: {}", e.getMessage());
-            return false;
+        } catch (ExpiredJwtException e) { // 토큰이 만료되었을 때
+            if(tokenType==TokenType.ACCESS)
+                throw new BusinessException(ExceptionType.EXPIRED_ACCESS_TOKEN);
+            else {
+                throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
+            }
+        }
+        catch (Exception e) { //토큰이 유효하지 않을 때
+            if(tokenType==TokenType.ACCESS)
+                throw new BusinessException(ExceptionType.INVALID_ACCESS_TOKEN);
+            else {
+                throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
+            }
         }
     }
 
@@ -98,5 +101,15 @@ public class TokenProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+    public void updateRefreshToken(String refreshToken,User user){
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findByUserId(user.getId())
+                .map(existingToken -> {
+                    existingToken.update(refreshToken); // 기존 토큰 업데이트
+                    return existingToken;
+                })
+                .orElseGet(() -> new RefreshToken(user.getId(), refreshToken)); // 없으면 새로 생성
+
+        refreshTokenRepository.save(refreshTokenEntity);
     }
 }

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenType.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenType.java
@@ -1,0 +1,6 @@
+package com.club_board.club_board_server.config.jwt;
+
+public enum TokenType {
+    ACCESS,
+    REFRESH
+}

--- a/src/main/java/com/club_board/club_board_server/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/security/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.club_board.club_board_server.config.security;
 import com.club_board.club_board_server.config.jwt.TokenAuthenticationFilter;
+import com.club_board.club_board_server.config.jwt.TokenExceptionHandlerFilter;
 import com.club_board.club_board_server.config.jwt.TokenProvider;
 import com.club_board.club_board_server.service.auth.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class WebSecurityConfig{
     private final CustomUserDetailsService customUserDetailsService;
     private static final String[] AUTH_WHITELIST = {
             "/register/**","/login/**","/post/**","/comment/**","/admin/**","/myPage/**","/board/**","/club/**", "/books/**", "/book/admin/**"
+            ,"/refreshToken/**"
     };
 
     @Bean
@@ -42,6 +44,7 @@ public class WebSecurityConfig{
                 );
         // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
         http.addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new TokenExceptionHandlerFilter(), TokenAuthenticationFilter.class);
         http.sessionManagement(sessionManagement->sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         // FormLogin, BasicHttp 비활성화
         http.formLogin(AbstractHttpConfigurer::disable);

--- a/src/main/java/com/club_board/club_board_server/controller/refreshToken/RefreshTokenController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/refreshToken/RefreshTokenController.java
@@ -1,9 +1,12 @@
 package com.club_board.club_board_server.controller.refreshToken;
 import com.club_board.club_board_server.response.ResponseUtil;
+import com.club_board.club_board_server.response.exception.BusinessException;
+import com.club_board.club_board_server.response.exception.ExceptionType;
 import com.club_board.club_board_server.service.auth.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,7 +18,10 @@ public class RefreshTokenController {
     private final AuthService authService;
 
     @PostMapping("/refreshToken")
-    public ResponseEntity<?> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
+    public ResponseEntity<?> refreshToken(@CookieValue(value="refresh-token", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            throw new BusinessException(ExceptionType.NOT_FOUND_REFRESH_TOKEN);
+        }
         String newAccessToken=authService.isValidRefreshToken(refreshToken);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(newAccessToken));
     }

--- a/src/main/java/com/club_board/club_board_server/repository/book/ReservationRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/book/ReservationRepository.java
@@ -20,7 +20,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
 
     @Query("SELECT r FROM Reservation r WHERE r.book.id = :bookId AND r.user.id=:userId AND r.status='RESERVED'")
-    Optional<Reservation> findReservedReservationByBookAndUser(Long bookId, Long userId);
+    Optional<Reservation> findReservedReservationByBookAndUser(@Param("bookId") Long bookId, @Param("userId") Long userId);
 
     // 마감 기한이 지난 예약 내역을 리스트로 가져오는 JPQL
     @Query("SELECT r FROM Reservation r JOIN FETCH r.user WHERE r.status='BORROWING' AND r.borrowDate < :overdueDate")

--- a/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
@@ -32,7 +32,10 @@ public enum ExceptionType {
     TEMPORARY_PASSWORD_ERROR(INTERNAL_SERVER_ERROR,"A004","임시 비밀번호 생성 오류"),
     INVALID_ACCESS_TOKEN(UNAUTHORIZED,"A005","Access Token 이 유효하지 않습니다."),
     NOT_FOUND_ACCESS_TOKEN(UNAUTHORIZED,"A006","Access Token 이 존재하지 않습니다."),
-    INVALID_REFRESH_TOKEN(UNAUTHORIZED,"A007","Refresh Token 만료"),
+    EXPIRED_ACCESS_TOKEN(UNAUTHORIZED,"A007","Access Token 만료"),
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED,"A008","Refresh Token 이 유효하지 않습니다."),
+    NOT_FOUND_REFRESH_TOKEN(UNAUTHORIZED,"A006","Refresh Token 이 존재하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,"A007","Refresh Token Token 만료"),
 
     // File
     FILE_NOT_FOUND(NOT_FOUND, "F001", "파일이 존재하지 않습니다."),

--- a/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
@@ -34,8 +34,8 @@ public enum ExceptionType {
     NOT_FOUND_ACCESS_TOKEN(UNAUTHORIZED,"A006","Access Token 이 존재하지 않습니다."),
     EXPIRED_ACCESS_TOKEN(UNAUTHORIZED,"A007","Access Token 만료"),
     INVALID_REFRESH_TOKEN(UNAUTHORIZED,"A008","Refresh Token 이 유효하지 않습니다."),
-    NOT_FOUND_REFRESH_TOKEN(UNAUTHORIZED,"A006","Refresh Token 이 존재하지 않습니다."),
-    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,"A007","Refresh Token Token 만료"),
+    NOT_FOUND_REFRESH_TOKEN(UNAUTHORIZED,"A009","Refresh Token 이 존재하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,"A0010","Refresh Token Token 만료"),
 
     // File
     FILE_NOT_FOUND(NOT_FOUND, "F001", "파일이 존재하지 않습니다."),

--- a/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
+++ b/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.club_board.club_board_server.service.auth;
 import com.club_board.club_board_server.config.jwt.TokenProvider;
+import com.club_board.club_board_server.config.jwt.TokenType;
 import com.club_board.club_board_server.domain.user.CustomUserDetails;
 import com.club_board.club_board_server.domain.RefreshToken;
 import com.club_board.club_board_server.domain.user.User;
@@ -61,14 +62,7 @@ public class AuthService {
             User user=userDetails.getUser();
             String accessToken=tokenProvider.generateAccessToken(user, Duration.ofHours(1));
             String refreshToken = tokenProvider.generateRefreshToken(user, Duration.ofDays(7));
-            RefreshToken refreshTokenEntity = refreshTokenRepository.findByUserId(user.getId())
-                    .map(existingToken -> {
-                        existingToken.update(refreshToken); // 기존 토큰 업데이트
-                        return existingToken;
-                    })
-                    .orElseGet(() -> new RefreshToken(user.getId(), refreshToken)); // 없으면 새로 생성
-
-            refreshTokenRepository.save(refreshTokenEntity);
+            tokenProvider.updateRefreshToken(refreshToken,user);
             Cookie cookie=setCookie(refreshToken);
             response.addCookie(cookie);
             String message = "로그인 성공";
@@ -127,21 +121,34 @@ public class AuthService {
             throw new BusinessException(ExceptionType.TEMPORARY_PASSWORD_ERROR);
         }
     }
+
     /*
     Refresh-Token 검증
      */
-    //TODO: AT를 재발급하고 다시 DB에 저장하는 로직이 필요함
     public String isValidRefreshToken(String refreshToken){
         try{
+            // DB에서 RefreshToken 존재 여부 확인
             refreshTokenRepository.findByRefreshToken(refreshToken).orElseThrow(
                     ()->new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN));
+            // 리프레시 토큰 유효성 검사
+            tokenProvider.validToken(refreshToken, TokenType.REFRESH);
+            // claims에서 유저 정보 가져오기
             String username=tokenProvider.getClaims(refreshToken).getSubject();
+            // username으로 UserDetails 조회
             CustomUserDetails userDetails=(CustomUserDetails) customUserDetailsService.loadUserByUsername(username);
-            return tokenProvider.generateAccessToken(userDetails.getUser(),Duration.ofHours(1));
+            User user=userDetails.getUser();
+            // RefreshToken 새로 생성 후 업데이트
+            tokenProvider.generateRefreshToken(user,Duration.ofDays(7));
+            tokenProvider.updateRefreshToken(refreshToken,user);
+            // AccessToken 재발급
+            return tokenProvider.generateAccessToken(user,Duration.ofHours(1));
+        }
+        catch (BusinessException be){
+            throw be;
         }
         catch (Exception e)
         {
-            throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
+            throw new BusinessException(ExceptionType.UNEXPECTED_SERVER_ERROR);
         }
     }
 
@@ -166,4 +173,5 @@ public class AuthService {
         }
         return shuffled.toString();
     }
+
 }

--- a/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
+++ b/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
@@ -2,7 +2,6 @@ package com.club_board.club_board_server.service.auth;
 import com.club_board.club_board_server.config.jwt.TokenProvider;
 import com.club_board.club_board_server.config.jwt.TokenType;
 import com.club_board.club_board_server.domain.user.CustomUserDetails;
-import com.club_board.club_board_server.domain.RefreshToken;
 import com.club_board.club_board_server.domain.user.User;
 import com.club_board.club_board_server.dto.auth.ResetPasswordRequest;
 import com.club_board.club_board_server.dto.auth.UserLoginRequest;
@@ -145,10 +144,6 @@ public class AuthService {
         }
         catch (BusinessException be){
             throw be;
-        }
-        catch (Exception e)
-        {
-            throw new BusinessException(ExceptionType.UNEXPECTED_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
+++ b/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
@@ -173,5 +173,4 @@ public class AuthService {
         }
         return shuffled.toString();
     }
-
 }

--- a/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
+++ b/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
@@ -149,8 +149,7 @@ public class AuthService {
 
     public Cookie setCookie(String refreshToken){
         String cookieName="refresh-token";
-        String cookieValue=refreshToken;
-        Cookie cookie=new Cookie(cookieName,cookieValue);
+        Cookie cookie=new Cookie(cookieName, refreshToken);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");


### PR DESCRIPTION
## ✨ PR 요약

- Access Token 로직 수정
- Refresh Token 로직 수정
- TokenType 추가
- ExceptionType 토큰 관련 예외 코드 추가
- 예외 커스텀 필터 추가


## 🔎 작업 상세
- 기존 validToken은 단순히 true,false만 반환하였습니다. 그러나 이는 토큰이 만료되었는지, 토큰이 서명 오류인지 예외를 세부적으로 다루지 못하기 때문에 수정했습니다. 이때 TokenType을 추가해서 AT일 때는 AT예외, RT일 때는 RT 예외를 던지도록 하였습니다.
- RefreshToken을 DB에 업데이트 해주는 updateRefreshToken 메서드를 정의했습니다.
- AT만료시 프론트에서 /refreshToken으로 요청할 때 처리하는 isValidRefreshToken을 수정하였습니다. 이때  RT의 존재 여부, 유효성을 검사한 다음 RT을 재발급하여 DB에 저장하고, AT를 return합니다.
- 필터에서 발생한 예외는 @RestControllerAdvice가 잡아주지 못하기 때문에, JWT 토큰 예외를 잡아주기 위해 커스텀 필터를 정의하였습니다.

## 💡기타 사항
- AT, RT의 유무, 유효성에 따른 토큰 로직 흐름이 올바른지 자세히 검토해주시면 좋을거 같습니다!

