### PR TITLE
refactor: RefreshToken 로직 수정

### DIFF
--- a/src/main/java/com/club_board/club_board_server/controller/refreshToken/RefreshTokenController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/refreshToken/RefreshTokenController.java
@@ -3,12 +3,12 @@ import com.club_board.club_board_server.response.ResponseUtil;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
 import com.club_board.club_board_server.service.auth.AuthService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RequiredArgsConstructor
@@ -18,11 +18,13 @@ public class RefreshTokenController {
     private final AuthService authService;
 
     @PostMapping("/refreshToken")
-    public ResponseEntity<?> refreshToken(@CookieValue(value="refresh-token", required = false) String refreshToken) {
+    public ResponseEntity<?> refreshToken(@CookieValue(value="refresh-token", required = false) String refreshToken,
+                                          HttpServletResponse response) {
         if (refreshToken == null) {
             throw new BusinessException(ExceptionType.NOT_FOUND_REFRESH_TOKEN);
         }
-        String newAccessToken=authService.isValidRefreshToken(refreshToken);
+
+        String newAccessToken = authService.validateAndHandleRefreshToken(refreshToken, response);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(newAccessToken));
     }
 }

--- a/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
+++ b/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
@@ -10,6 +10,7 @@ import com.club_board.club_board_server.repository.refreshToken.RefreshTokenRepo
 import com.club_board.club_board_server.repository.user.UserRepository;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
@@ -23,6 +24,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import java.security.SecureRandom;
 import java.time.Duration;
+
+
 @RequiredArgsConstructor
 @Service
 @Slf4j
@@ -40,7 +43,6 @@ public class AuthService {
     private static final int MAX_PASSWORD_LENGTH=20;
     private static final SecureRandom RANDOM=new SecureRandom();
     private final PasswordEncoder passwordEncoder;
-    private final CustomUserDetailsService customUserDetailsService;
     private final RefreshTokenRepository refreshTokenRepository;
 
     /*
@@ -124,25 +126,35 @@ public class AuthService {
     /*
     Refresh-Token 검증
      */
-    public String isValidRefreshToken(String refreshToken){
-        try{
-            // DB에서 RefreshToken 존재 여부 확인
-            refreshTokenRepository.findByRefreshToken(refreshToken).orElseThrow(
-                    ()->new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN));
-            // 리프레시 토큰 유효성 검사
+    public String validateAndHandleRefreshToken(String refreshToken, HttpServletResponse response) {
+        try {
+            // DB에서 Refresh Token 확인
+            refreshTokenRepository.findByRefreshToken(refreshToken)
+                    .orElseThrow(() -> new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN));
+
+            // Refresh Token 유효성 검사
             tokenProvider.validToken(refreshToken, TokenType.REFRESH);
-            // claims에서 유저 정보 가져오기
-            String username=tokenProvider.getClaims(refreshToken).getSubject();
-            // username으로 UserDetails 조회
-            CustomUserDetails userDetails=(CustomUserDetails) customUserDetailsService.loadUserByUsername(username);
-            User user=userDetails.getUser();
-            // RefreshToken 새로 생성 후 업데이트
-            tokenProvider.generateRefreshToken(user,Duration.ofDays(7));
-            tokenProvider.updateRefreshToken(refreshToken,user);
-            // AccessToken 재발급
-            return tokenProvider.generateAccessToken(user,Duration.ofHours(1));
-        }
-        catch (BusinessException be){
+
+            // 토큰에서 유저 ID 추출 및 유저 조회
+            Long userId = tokenProvider.getClaims(refreshToken).get("id", Long.class);
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+            // Refresh Token 만료 임박 시 새로 발급
+            Claims claims = tokenProvider.getClaims(refreshToken);
+            long remainingTime = claims.getExpiration().getTime() - System.currentTimeMillis();
+            if (remainingTime < Duration.ofDays(1).toMillis()) { // 1일 이하 남은 경우
+                String newRefreshToken = tokenProvider.generateRefreshToken(user, Duration.ofDays(7));
+                tokenProvider.updateRefreshToken(newRefreshToken, user);
+
+                // Cookie에 새 Refresh Token 저장
+                Cookie cookie = setCookie(newRefreshToken);
+                response.addCookie(cookie);
+            }
+
+            // Access Token 발급
+            return tokenProvider.generateAccessToken(user, Duration.ofHours(1));
+        } catch (BusinessException be) {
             throw be;
         }
     }
@@ -153,7 +165,7 @@ public class AuthService {
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
-        cookie.setMaxAge(60*60*24);
+        cookie.setMaxAge(60*60*24*7);
         return cookie;
     }
 


### PR DESCRIPTION
## ✨ PR 요약

- Refresh Token 로직 수정


## 🔎 작업 상세

- 기존에는 Refresh Token을 무조건적으로 업데이트를 했습니다. 하지만 요청이 들어올 때마다 갱신되는 것은 비효율적이라고 생각해서, 만료기간이 1일 남았을 때 재발급 하도록 설정했습니다.
- 쿠키 설정 시 쿠키 접근 시간이 1일로 되어있어서 7일로 수정했습니다.
- 쿠키 setSecure에서 속성이 true 일 때, HTTPS 환경이 아니면 전달이 되지 않을 수 있다고 합니다. 이는 나중에 프론트랑 테스트해보면서 검토 해봐야할거 같습니다
