### PR TITLE
✨feat: 예약/대여/반납 조회 시 N+1 문제 해결

### DIFF
--- a/src/main/java/com/club_board/club_board_server/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/security/WebSecurityConfig.java
@@ -29,7 +29,7 @@ public class WebSecurityConfig{
     private final CustomUserDetailsService customUserDetailsService;
     private static final String[] AUTH_WHITELIST = {
             "/register/**","/login/**","/post/**","/comment/**","/admin/**","/myPage/**","/board/**","/club/**", "/books/**", "/book/admin/**"
-            ,"/refreshToken/**"
+            ,"/refreshToken/**", "/files/**"
     };
 
     @Bean

--- a/src/main/java/com/club_board/club_board_server/controller/book/BookAdminController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/book/BookAdminController.java
@@ -9,6 +9,8 @@ import com.club_board.club_board_server.service.book.BookAdminService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -60,7 +62,9 @@ public class BookAdminController {
 
     @GetMapping("/returns")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
-    public ResponseEntity<ResponseBody<BookReturnResponse>> getReturns(Pageable pageable) {
+    public ResponseEntity<ResponseBody<BookReturnResponse>> getReturns(
+            @PageableDefault(size = 20, direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         BookReturnResponse response = bookAdminService.getReturns(pageable);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }

--- a/src/main/java/com/club_board/club_board_server/controller/book/BookAdminController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/book/BookAdminController.java
@@ -48,14 +48,18 @@ public class BookAdminController {
 
     @GetMapping("/reservations")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
-    public ResponseEntity<ResponseBody<BookReservationResponse>> getReservations(Pageable pageable) {
+    public ResponseEntity<ResponseBody<BookReservationResponse>> getReservations(
+            @PageableDefault(sort = "reservationDate") Pageable pageable
+    ) {
         BookReservationResponse response = bookAdminService.getReservations(pageable);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }
 
     @GetMapping("/loans")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
-    public ResponseEntity<ResponseBody<BookLoanResponse>> getLoans(Pageable pageable) {
+    public ResponseEntity<ResponseBody<BookLoanResponse>> getLoans(
+            @PageableDefault(sort = "borrowDate") Pageable pageable
+    ) {
         BookLoanResponse response = bookAdminService.getLoans(pageable);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }
@@ -63,7 +67,7 @@ public class BookAdminController {
     @GetMapping("/returns")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public ResponseEntity<ResponseBody<BookReturnResponse>> getReturns(
-            @PageableDefault(size = 20, direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(sort = "returnDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         BookReturnResponse response = bookAdminService.getReturns(pageable);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));

--- a/src/main/java/com/club_board/club_board_server/dto/bookAdmin/response/BookLoan.java
+++ b/src/main/java/com/club_board/club_board_server/dto/bookAdmin/response/BookLoan.java
@@ -1,12 +1,12 @@
 package com.club_board.club_board_server.dto.bookAdmin.response;
 
-import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+import static com.club_board.club_board_server.service.book.BookAdminService.MAX_LOAN_PERIOD_DAYS;
+
 @Getter
-@Builder
 public class BookLoan {
     private Long bookId;
     private String bookTitle;
@@ -15,4 +15,14 @@ public class BookLoan {
     private String userName;
     private LocalDateTime borrowDate;
     private LocalDateTime returnDueDate;
+
+    public BookLoan(Long bookId, String bookTitle, Long reservationId, Long userId, String userName, LocalDateTime borrowDate) {
+        this.bookId = bookId;
+        this.bookTitle = bookTitle;
+        this.reservationId = reservationId;
+        this.userId = userId;
+        this.userName = userName;
+        this.borrowDate = borrowDate;
+        this.returnDueDate = borrowDate.plusDays(MAX_LOAN_PERIOD_DAYS);
+    }
 }

--- a/src/main/java/com/club_board/club_board_server/dto/bookAdmin/response/BookReservation.java
+++ b/src/main/java/com/club_board/club_board_server/dto/bookAdmin/response/BookReservation.java
@@ -1,12 +1,10 @@
 package com.club_board.club_board_server.dto.bookAdmin.response;
 
-import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
 public class BookReservation {
     private Long bookId;
     private String bookTitle;
@@ -14,5 +12,14 @@ public class BookReservation {
     private Long userId;
     private String userName;
     private LocalDateTime reservationDate;
+
+    public BookReservation(Long bookId, String bookTitle, Long reservationId, Long userId, String userName, LocalDateTime reservationDate) {
+        this.bookId = bookId;
+        this.bookTitle = bookTitle;
+        this.reservationId = reservationId;
+        this.userId = userId;
+        this.userName = userName;
+        this.reservationDate = reservationDate;
+    }
 }
 

--- a/src/main/java/com/club_board/club_board_server/dto/bookAdmin/response/BookReturn.java
+++ b/src/main/java/com/club_board/club_board_server/dto/bookAdmin/response/BookReturn.java
@@ -1,12 +1,10 @@
 package com.club_board.club_board_server.dto.bookAdmin.response;
 
-import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
 public class BookReturn {
     private Long bookId;
     private String bookTitle;
@@ -15,4 +13,14 @@ public class BookReturn {
     private String userName;
     private LocalDateTime borrowDate;
     private LocalDateTime returnDate;
+
+    public BookReturn(Long bookId, String bookTitle, Long reservationId, Long userId, String userName, LocalDateTime borrowDate, LocalDateTime returnDate) {
+        this.bookId = bookId;
+        this.bookTitle = bookTitle;
+        this.reservationId = reservationId;
+        this.userId = userId;
+        this.userName = userName;
+        this.borrowDate = borrowDate;
+        this.returnDate = returnDate;
+    }
 }

--- a/src/main/java/com/club_board/club_board_server/repository/book/ReservationRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/book/ReservationRepository.java
@@ -1,7 +1,9 @@
 package com.club_board.club_board_server.repository.book;
 
 import com.club_board.club_board_server.domain.book.Reservation;
-import com.club_board.club_board_server.domain.book.ReservationStatus;
+import com.club_board.club_board_server.dto.bookAdmin.response.BookLoan;
+import com.club_board.club_board_server.dto.bookAdmin.response.BookReservation;
+import com.club_board.club_board_server.dto.bookAdmin.response.BookReturn;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,11 +31,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("SELECT r FROM Reservation r JOIN FETCH r.user WHERE r.status='BORROWING' AND r.borrowDate < :overdueDate")
     List<Reservation> findAllOverdueReservations(@Param("overdueDate") LocalDateTime overdueDate);
 
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.book b JOIN FETCH r.user u WHERE r.status=:status")
-    Page<Reservation> findAllByOneStatus(@Param("status") ReservationStatus status, Pageable pageable);
+    @Query("SELECT new com.club_board.club_board_server.dto.bookAdmin.response.BookReservation(" +
+            "b.id, b.title, r.id, u.id, u.name, r.reservationDate) " +
+            "FROM Reservation r JOIN r.book b JOIN r.user u WHERE r.status='RESERVED'")
+    Page<BookReservation> findAllReservations(Pageable pageable);
 
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.book b JOIN FETCH r.user u WHERE r.status=:status1 OR r.status=:status2")
-    Page<Reservation> findAllByTwoStatus(@Param("status1") ReservationStatus status1, @Param("status2") ReservationStatus status2, Pageable pageable);
+    @Query("SELECT new com.club_board.club_board_server.dto.bookAdmin.response.BookLoan(" +
+            "b.id, b.title, r.id, u.id, u.name, r.borrowDate) " +
+            "FROM Reservation r JOIN r.book b JOIN r.user u WHERE r.status='BORROWING' OR r.status='OVERDUE'")
+    Page<BookLoan> findAllLoans(Pageable pageable);
+
+    @Query("SELECT new com.club_board.club_board_server.dto.bookAdmin.response.BookReturn(" +
+            "b.id, b.title, r.id, u.id, u.name, r.borrowDate, r.returnDate) " +
+            "FROM Reservation r JOIN r.book b JOIN r.user u WHERE r.status='RETURNED' OR r.status='OVERDUE_RETURNED'")
+    Page<BookReturn> findAllReturns(Pageable pageable);
 
     @Query("SELECT r FROM Reservation r WHERE r.book.id=:bookId AND (r.status='BORROWING' OR r.status='OVERDUE')")
     List<Reservation> findByBookAndBorrowingStatus(Long bookId);

--- a/src/main/java/com/club_board/club_board_server/service/book/BookAdminService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookAdminService.java
@@ -23,13 +23,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class BookAdminService {
-    private static final int MAX_LOAN_PERIOD_DAYS = 14;
+    public static final int MAX_LOAN_PERIOD_DAYS = 14;
 
     private final BookRepository bookRepository;
     private final BookImageRepository bookImageRepository;
@@ -87,67 +86,30 @@ public class BookAdminService {
 
     @Transactional(readOnly = true)
     public BookReservationResponse getReservations(Pageable pageable) {
-        Page<Reservation> reservationPage = reservationRepository.findAllByOneStatus(ReservationStatus.RESERVED, pageable);
-
-        List<BookReservation> reservations = reservationPage.stream()
-                .map(reservation -> BookReservation.builder()
-                        .bookId(reservation.getBook().getId())
-                        .bookTitle(reservation.getBook().getTitle())
-                        .reservationId(reservation.getId())
-                        .userId(reservation.getUser().getId())
-                        .userName(reservation.getUser().getName())
-                        .reservationDate(reservation.getReservationDate())
-                        .build()
-                ).toList();
+        Page<BookReservation> reservationPage = reservationRepository.findAllReservations(pageable);
 
         return BookReservationResponse.builder()
-                .reservations(reservations)
+                .reservations(reservationPage.toList())
                 .paging(PageInfo.from(pageable, reservationPage))
                 .build();
     }
 
     @Transactional(readOnly = true)
     public BookLoanResponse getLoans(Pageable pageable) {
-        Page<Reservation> reservationPage = reservationRepository
-                .findAllByTwoStatus(ReservationStatus.BORROWING, ReservationStatus.OVERDUE, pageable);
-
-        List<BookLoan> loans = reservationPage.stream()
-                .map(reservation -> BookLoan.builder()
-                        .bookId(reservation.getBook().getId())
-                        .bookTitle(reservation.getBook().getTitle())
-                        .reservationId(reservation.getId())
-                        .userId(reservation.getUser().getId())
-                        .userName(reservation.getUser().getName())
-                        .borrowDate(reservation.getBorrowDate())
-                        .returnDueDate(reservation.getBorrowDate().plusDays(MAX_LOAN_PERIOD_DAYS))
-                        .build()
-                ).toList();
+        Page<BookLoan> reservationPage = reservationRepository.findAllLoans(pageable);
 
         return BookLoanResponse.builder()
-                .loans(loans)
+                .loans(reservationPage.toList())
                 .paging(PageInfo.from(pageable, reservationPage))
                 .build();
     }
 
     @Transactional(readOnly = true)
     public BookReturnResponse getReturns(Pageable pageable) {
-        Page<Reservation> reservationPage = reservationRepository
-                .findAllByTwoStatus(ReservationStatus.RETURNED, ReservationStatus.OVERDUE_RETURNED, pageable);
-
-        List<BookReturn> returns = reservationPage.stream()
-                .map(reservation -> BookReturn.builder()
-                        .bookId(reservation.getBook().getId())
-                        .bookTitle(reservation.getBook().getTitle())
-                        .reservationId(reservation.getId())
-                        .userId(reservation.getUser().getId())
-                        .userName(reservation.getUser().getName())
-                        .borrowDate(reservation.getBorrowDate())
-                        .returnDate(reservation.getReturnDate())
-                        .build()
-                ).toList();
+        Page<BookReturn> reservationPage = reservationRepository.findAllReturns(pageable);
 
         return BookReturnResponse.builder()
-                .returns(returns)
+                .returns(reservationPage.toList())
                 .paging(PageInfo.from(pageable, reservationPage))
                 .build();
     }


### PR DESCRIPTION
## ✨ PR 요약

- 예약/대여/반납 조회 시 N+1 문제를 해결하기 위해 DTO로 데이터를 조회하는 것으로 변경


## 🔎 작업 상세

- 예약/대여/반납 조회 시 기존 DTO(`BookReservation`, `BookLoan`, `BookReturn`)를 JPQL 작성에 활용하여 필요한 필드만 가져오게 변경
  - `@OneToOne`에서 주인이 아닌 쪽에서는 `FetchType`를 `LAZY`로 설정 해주어도 `EAGER`로 동작한다고 합니다. 따라서 주인을 바꾸거나, 로직을 변경하는 것이 근본적인 해결책이겠지만, 우선 데이터 변경도 코드 변경도 가장 적은 해당 방법을 선택했습니다.
- file 관련 엔드포인트를 `WebSecurityConfig`의 `AUTH_WHITELIST`에 추가
- 반납 조회 Pageable 기본 값을 최신 순으로 변경(다른 것은 오래된 순 유지)
- 예약/대여/반납 조회 모두 기본 size 10으로 변경(`@PageableDefault`의 기본 값), 각각에 맞는 기본 정렬 필드 지정
