### PR TITLE
:sparkles:feat: 권한이 없는 경우에 대한 예외 응답 추가

### DIFF
--- a/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
@@ -14,6 +14,7 @@ public enum ExceptionType {
     ESSENTIAL_FIELD_MISSING_ERROR(NO_CONTENT , "C003","필수적인 필드 부재"),
     INVALID_JSON_FORMAT(BAD_REQUEST, "C004", "잘못된 JSON 데이터 형식"),
 
+
     //User
     USER_ALREADY_EXIST(HttpStatus.CONFLICT,"U001","이미 존재하는 회원입니다."),
     USER_NOT_FOUND(NOT_FOUND,"U002","존재하지 않는 유저입니다."),
@@ -36,7 +37,8 @@ public enum ExceptionType {
     EXPIRED_ACCESS_TOKEN(UNAUTHORIZED,"A007","Access Token 만료"),
     INVALID_REFRESH_TOKEN(UNAUTHORIZED,"A008","Refresh Token 이 유효하지 않습니다."),
     NOT_FOUND_REFRESH_TOKEN(UNAUTHORIZED,"A009","Refresh Token 이 존재하지 않습니다."),
-    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,"A0010","Refresh Token Token 만료"),
+    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,"A010","Refresh Token Token 만료"),
+    AUTHORIZATION_DENIED(FORBIDDEN, "A011", "권한이 없습니다."),
 
     // File
     FILE_NOT_FOUND(NOT_FOUND, "F001", "파일이 존재하지 않습니다."),

--- a/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -23,6 +24,13 @@ public class GlobalExceptionHandler {
         ExceptionType exceptionType = e.getExceptionType();
         return ResponseEntity.status(exceptionType.getStatus())
                 .body(ResponseUtil.createFailureResponse(exceptionType));
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ResponseBody<Void>> authorizationDeniedException(AuthorizationDeniedException e){
+        return ResponseEntity
+                .status(ExceptionType.AUTHORIZATION_DENIED.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.AUTHORIZATION_DENIED));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -56,6 +64,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseBody<Void>> exception(Exception e){
+        e.printStackTrace();
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ResponseUtil.createFailureResponse(ExceptionType.UNEXPECTED_SERVER_ERROR));


### PR DESCRIPTION
## ✨ PR 요약

- 접근 권한이 없는 사용자에 대한 전역 핸들러 추가


## 🔎 작업 상세

- `ExceptionType`에 변경
  - `AUTHORIZATION_DENIED` 타입 추가
  - `EXPIRED_REFRESH_TOKEN`의 code의 숫자 부분을 3자리로 수정
- `GlobalExceptionHandler`에 `AuthorizationDeniedException`에 대한 핸들러 추가