### PR TITLE
마이페이지 회원별 도서현황 api

### DIFF
--- a/src/main/java/com/club_board/club_board_server/controller/mypage/MyLoanController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/mypage/MyLoanController.java
@@ -2,6 +2,7 @@ package com.club_board.club_board_server.controller.mypage;
 
 import com.club_board.club_board_server.dto.myPage.book.MyLoanResponse;
 import com.club_board.club_board_server.dto.myPage.book.MyReservationResponse;
+import com.club_board.club_board_server.dto.myPage.book.MyReturnResponse;
 import com.club_board.club_board_server.response.ResponseBody;
 import com.club_board.club_board_server.response.ResponseUtil;
 import com.club_board.club_board_server.service.myPage.MyLoanService;
@@ -38,8 +39,8 @@ public class MyLoanController {
 
     @GetMapping("/return/{userId}")
     @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<?> getReturnStatus(@PathVariable("userId") @P("userId") Long userId){
-        List<MyLoanResponse> myLoanResponse=myLoanService.getMyLoan(userId);
+    public ResponseEntity<ResponseBody<List<MyReturnResponse>>> getReturnStatus(@PathVariable("userId") @P("userId") Long userId){
+        List<MyReturnResponse> myLoanResponse=myLoanService.getMyReturn(userId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myLoanResponse));
     }
 }

--- a/src/main/java/com/club_board/club_board_server/controller/mypage/MyLoanController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/mypage/MyLoanController.java
@@ -1,0 +1,45 @@
+package com.club_board.club_board_server.controller.mypage;
+
+import com.club_board.club_board_server.dto.myPage.book.MyLoanResponse;
+import com.club_board.club_board_server.dto.myPage.book.MyReservationResponse;
+import com.club_board.club_board_server.response.ResponseBody;
+import com.club_board.club_board_server.response.ResponseUtil;
+import com.club_board.club_board_server.service.myPage.MyLoanService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/myPage")
+@RequiredArgsConstructor
+public class MyLoanController {
+
+    private final MyLoanService myLoanService;
+    @GetMapping("/loan/{userId}")
+    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
+    public ResponseEntity<ResponseBody<List<MyLoanResponse>>> getLoanStatus(@PathVariable("userId") @P("userId") Long userId){
+        List<MyLoanResponse> myLoanResponse=myLoanService.getMyLoan(userId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myLoanResponse));
+    }
+
+    @GetMapping("/reservation/{userId}")
+    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
+    public ResponseEntity<ResponseBody<List<MyReservationResponse>>> getReservationStatus(@PathVariable("userId") @P("userId") Long userId){
+        List<MyReservationResponse> myReservationResponse=myLoanService.getMyReservations(userId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myReservationResponse));
+    }
+
+    @GetMapping("/return/{userId}")
+    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
+    public ResponseEntity<?> getReturnStatus(@PathVariable("userId") @P("userId") Long userId){
+        List<MyLoanResponse> myLoanResponse=myLoanService.getMyLoan(userId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myLoanResponse));
+    }
+}

--- a/src/main/java/com/club_board/club_board_server/controller/mypage/MyPageController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/mypage/MyPageController.java
@@ -1,6 +1,6 @@
 package com.club_board.club_board_server.controller.mypage;
-import com.club_board.club_board_server.dto.myPage.MyPageResponse;
-import com.club_board.club_board_server.dto.myPage.UpdateMyPageRequest;
+import com.club_board.club_board_server.dto.myPage.userInfo.UserInfoResponse;
+import com.club_board.club_board_server.dto.myPage.userInfo.UpdateUserInfoRequest;
 import com.club_board.club_board_server.response.ResponseBody;
 import com.club_board.club_board_server.response.ResponseUtil;
 import com.club_board.club_board_server.service.myPage.MyPageService;
@@ -14,21 +14,22 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/myPage")
 public class MyPageController {
 
     private final MyPageService myPageService;
 
-    @GetMapping("/myPage/{userId}")
+    @GetMapping("/{userId}")
     @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<ResponseBody<MyPageResponse>> showMyPage(@PathVariable("userId") @P("userId") Long userId){
-        MyPageResponse myPageResponse=myPageService.getMyPage(userId);
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myPageResponse));
+    public ResponseEntity<ResponseBody<UserInfoResponse>> showMyPage(@PathVariable("userId") @P("userId") Long userId){
+        UserInfoResponse userInfoResponse =myPageService.getMyPage(userId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(userInfoResponse));
     }
 
-    @PatchMapping("/myPage/{userId}")
+    @PatchMapping("/{userId}")
     @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<ResponseBody<String>> updateMyPage(@PathVariable("userId") @P("userId") Long userId, @RequestBody UpdateMyPageRequest updateMyPageRequest){
-        myPageService.updateMyPage(userId,updateMyPageRequest);
+    public ResponseEntity<ResponseBody<String>> updateMyPage(@PathVariable("userId") @P("userId") Long userId, @RequestBody UpdateUserInfoRequest updateUserInfoRequest){
+        myPageService.updateMyPage(userId, updateUserInfoRequest);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse("유저 정보 업데이트 성공"));
     }
 }

--- a/src/main/java/com/club_board/club_board_server/domain/user/User.java
+++ b/src/main/java/com/club_board/club_board_server/domain/user/User.java
@@ -1,5 +1,5 @@
 package com.club_board.club_board_server.domain.user;
-import com.club_board.club_board_server.dto.myPage.UpdateUserCommand;
+import com.club_board.club_board_server.dto.myPage.userInfo.UpdateUserCommand;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/club_board/club_board_server/dto/auth/UserLoginResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/auth/UserLoginResponse.java
@@ -1,5 +1,6 @@
 package com.club_board.club_board_server.dto.auth;
 
+import com.club_board.club_board_server.domain.user.Role;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
@@ -12,8 +13,13 @@ public class UserLoginResponse {
     @NotBlank
     private String accessToken;
 
-    public UserLoginResponse(String message ,String accessToken) {
+    @NotBlank
+    private Role role;
+
+
+    public UserLoginResponse(String message ,String accessToken,Role role) {
         this.message = message;
         this.accessToken = accessToken;
+        this.role=role;
     }
 }

--- a/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyLoanResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyLoanResponse.java
@@ -1,0 +1,14 @@
+package com.club_board.club_board_server.dto.myPage.book;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MyLoanResponse {
+    private Long bookId;
+    private String bookName;
+    private LocalDateTime loanDate;
+    private LocalDateTime returnDate;
+    private int overdueDate;
+}

--- a/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyReservationResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyReservationResponse.java
@@ -1,0 +1,12 @@
+package com.club_board.club_board_server.dto.myPage.book;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MyReservationResponse {
+    private Long bookId;
+    private String bookName;
+    private LocalDateTime reservationDate;
+}

--- a/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyReturnResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyReturnResponse.java
@@ -1,0 +1,13 @@
+package com.club_board.club_board_server.dto.myPage.book;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MyReturnResponse {
+    private Long bookId;
+    private String bookName;
+    private LocalDateTime loanDate;
+    private LocalDateTime returnDate;
+}

--- a/src/main/java/com/club_board/club_board_server/dto/myPage/userInfo/UpdateUserCommand.java
+++ b/src/main/java/com/club_board/club_board_server/dto/myPage/userInfo/UpdateUserCommand.java
@@ -1,4 +1,4 @@
-package com.club_board.club_board_server.dto.myPage;
+package com.club_board.club_board_server.dto.myPage.userInfo;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/club_board/club_board_server/dto/myPage/userInfo/UpdateUserInfoRequest.java
+++ b/src/main/java/com/club_board/club_board_server/dto/myPage/userInfo/UpdateUserInfoRequest.java
@@ -1,10 +1,11 @@
-package com.club_board.club_board_server.dto.myPage;
+package com.club_board.club_board_server.dto.myPage.userInfo;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
-public class UpdateMyPageRequest {
+public class UpdateUserInfoRequest {
 
     @NotBlank
     private String prePassword;
@@ -17,7 +18,7 @@ public class UpdateMyPageRequest {
     @NotBlank
     private String department;
 
-    @NotBlank
+    @NotNull
     private int grade;
 
     @NotBlank
@@ -25,15 +26,15 @@ public class UpdateMyPageRequest {
             regexp = "^\\d{3}-\\d{4}-\\d{4}$")
     private String phoneNumber;
 
-    @NotBlank
+    @NotNull
     private Boolean departmentPublic;
 
-    @NotBlank
+    @NotNull
     private Boolean studentIdPublic;
 
-    @NotBlank
+    @NotNull
     private Boolean gradePublic;
 
-    @NotBlank
+    @NotNull
     private Boolean phonePublic;
 }

--- a/src/main/java/com/club_board/club_board_server/dto/myPage/userInfo/UserInfoResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/myPage/userInfo/UserInfoResponse.java
@@ -1,9 +1,9 @@
-package com.club_board.club_board_server.dto.myPage;
+package com.club_board.club_board_server.dto.myPage.userInfo;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class MyPageResponse {
+public class UserInfoResponse {
     private String role;
     private String username;
     private String name;
@@ -17,7 +17,7 @@ public class MyPageResponse {
     private boolean phonePublic;
 
     @Builder
-    public MyPageResponse(String role,String username,String name, String department, String studentId, int grade, String phoneNumber
+    public UserInfoResponse(String role, String username, String name, String department, String studentId, int grade, String phoneNumber
     , boolean departmentPublic, boolean studentIdPublic, boolean gradePublic, boolean phonePublic) {
         this.role = role;
         this.username = username;

--- a/src/main/java/com/club_board/club_board_server/repository/reservation/ReservationRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/reservation/ReservationRepository.java
@@ -1,10 +1,12 @@
-package com.club_board.club_board_server.repository.book;
-
+package com.club_board.club_board_server.repository.reservation;
 import com.club_board.club_board_server.domain.book.Book;
 import com.club_board.club_board_server.domain.book.Reservation;
 import com.club_board.club_board_server.dto.bookAdmin.response.BookLoan;
 import com.club_board.club_board_server.dto.bookAdmin.response.BookReservation;
 import com.club_board.club_board_server.dto.bookAdmin.response.BookReturn;
+import com.club_board.club_board_server.dto.myPage.book.MyLoanResponse;
+import com.club_board.club_board_server.dto.myPage.book.MyReservationResponse;
+import com.club_board.club_board_server.dto.myPage.book.MyReturnResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -26,6 +28,25 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("SELECT r From Reservation r WHERE r.book.id=:bookId AND r.user.id=:userId")
     Optional<Reservation> findReservationByBookAndUserId(@Param("bookId") Long bookId, @Param("userId") Long userId);
+
+    @Query("select new com.club_board.club_board_server.dto.myPage.book.MyLoanResponse(" +
+            "b.id, b.title, r.borrowDate, r.returnDate, " +
+            "CAST(function('DATEDIFF', current_date, r.returnDate) AS int)) " +
+            "from Reservation r join r.book b " +
+            "where r.user.id = :userId and (r.status = 'BORROWING' or r.status='OVERDUE')")
+    List<MyLoanResponse> findUserLoans(@Param("userId") Long userId);
+
+    @Query("select new com.club_board.club_board_server.dto.myPage.book.MyReservationResponse(" +
+            "b.id, b.title, r.reservationDate) " +
+            "from Reservation r join r.book b " +
+            "where r.user.id = :userId and r.status = 'RESERVED'")
+    List<MyReservationResponse> findUserReservations(@Param("userId") Long userId);
+
+    @Query("select new com.club_board.club_board_server.dto.myPage.book.MyReturnResponse(" +
+            "b.id, b.title, r.borrowDate, r.returnDate) " +
+            "from Reservation r join r.book b " +
+            "where r.user.id = :userId and (r.status = 'RETURNED' or r.status='OVERDUE_RETURNED')")
+    List<MyReturnResponse> findUserReturns(@Param("userId") Long userId);
 
     @Query("SELECT r FROM Reservation r WHERE r.book.id = :bookId AND r.user.id=:userId AND r.status='RESERVED'")
     Optional<Reservation> findReservedReservationByBookAndUser(@Param("bookId") Long bookId, @Param("userId") Long userId);

--- a/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
+++ b/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
@@ -70,7 +70,7 @@ public class AuthService {
             String refreshToken = generateAndStoreRefreshToken(user, userAgent);
             addRefreshTokenCookie(response,refreshToken);
             String message = "로그인 성공";
-            return new UserLoginResponse(message,accessToken);
+            return new UserLoginResponse(message,accessToken,user.getRole());
         }
         catch (Exception e)
         {

--- a/src/main/java/com/club_board/club_board_server/service/book/BookAdminService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookAdminService.java
@@ -10,7 +10,7 @@ import com.club_board.club_board_server.dto.bookAdmin.response.*;
 import com.club_board.club_board_server.dto.pageable.PageInfo;
 import com.club_board.club_board_server.repository.book.BookImageRepository;
 import com.club_board.club_board_server.repository.book.BookRepository;
-import com.club_board.club_board_server.repository.book.ReservationRepository;
+import com.club_board.club_board_server.repository.reservation.ReservationRepository;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
 import com.club_board.club_board_server.service.file.S3Service;

--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -6,7 +6,7 @@ import com.club_board.club_board_server.domain.book.ReservationStatus;
 import com.club_board.club_board_server.domain.user.User;
 import com.club_board.club_board_server.dto.book.BookResponse;
 import com.club_board.club_board_server.repository.book.BookRepository;
-import com.club_board.club_board_server.repository.book.ReservationRepository;
+import com.club_board.club_board_server.repository.reservation.ReservationRepository;
 import com.club_board.club_board_server.repository.user.UserRepository;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;

--- a/src/main/java/com/club_board/club_board_server/service/myPage/MyLoanService.java
+++ b/src/main/java/com/club_board/club_board_server/service/myPage/MyLoanService.java
@@ -1,6 +1,4 @@
 package com.club_board.club_board_server.service.myPage;
-
-
 import com.club_board.club_board_server.dto.myPage.book.MyLoanResponse;
 import com.club_board.club_board_server.dto.myPage.book.MyReservationResponse;
 import com.club_board.club_board_server.dto.myPage.book.MyReturnResponse;

--- a/src/main/java/com/club_board/club_board_server/service/myPage/MyLoanService.java
+++ b/src/main/java/com/club_board/club_board_server/service/myPage/MyLoanService.java
@@ -1,0 +1,29 @@
+package com.club_board.club_board_server.service.myPage;
+
+
+import com.club_board.club_board_server.dto.myPage.book.MyLoanResponse;
+import com.club_board.club_board_server.dto.myPage.book.MyReservationResponse;
+import com.club_board.club_board_server.dto.myPage.book.MyReturnResponse;
+import com.club_board.club_board_server.repository.reservation.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MyLoanService {
+
+    private final ReservationRepository reservationRepository;
+    public List<MyLoanResponse> getMyLoan(Long userId){
+        return reservationRepository.findUserLoans(userId);
+    }
+
+    public List<MyReturnResponse> getMyReturn(Long userId){
+        return reservationRepository.findUserReturns(userId);
+    }
+
+    public List<MyReservationResponse> getMyReservations(Long userId){
+        return reservationRepository.findUserReservations(userId);
+    }
+}

--- a/src/main/java/com/club_board/club_board_server/service/myPage/MyPageService.java
+++ b/src/main/java/com/club_board/club_board_server/service/myPage/MyPageService.java
@@ -1,8 +1,8 @@
 package com.club_board.club_board_server.service.myPage;
 import com.club_board.club_board_server.domain.user.User;
-import com.club_board.club_board_server.dto.myPage.MyPageResponse;
-import com.club_board.club_board_server.dto.myPage.UpdateMyPageRequest;
-import com.club_board.club_board_server.dto.myPage.UpdateUserCommand;
+import com.club_board.club_board_server.dto.myPage.userInfo.UserInfoResponse;
+import com.club_board.club_board_server.dto.myPage.userInfo.UpdateUserInfoRequest;
+import com.club_board.club_board_server.dto.myPage.userInfo.UpdateUserCommand;
 import com.club_board.club_board_server.repository.user.UserRepository;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
@@ -18,10 +18,10 @@ import org.springframework.stereotype.Service;
 public class MyPageService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    public MyPageResponse getMyPage(Long userId){
+    public UserInfoResponse getMyPage(Long userId){
         User user=userRepository.findById(userId)
                 .orElseThrow(()->new BusinessException(ExceptionType.USER_NOT_FOUND));
-        return MyPageResponse.builder()
+        return UserInfoResponse.builder()
                 .role(user.getRole().getDisplayName())
                 .username(user.getUsername())
                 .name(user.getName())
@@ -37,22 +37,22 @@ public class MyPageService {
     }
 
     @Transactional
-    public void updateMyPage(Long userId, UpdateMyPageRequest updateMyPageRequest){
+    public void updateMyPage(Long userId, UpdateUserInfoRequest updateUserInfoRequest){
         User user=userRepository.findById(userId)
                 .orElseThrow(()->new BusinessException(ExceptionType.USER_NOT_FOUND));
-        if(!passwordEncoder.matches(updateMyPageRequest.getPrePassword(), user.getPassword())){
+        if(!passwordEncoder.matches(updateUserInfoRequest.getPrePassword(), user.getPassword())){
             throw new BusinessException(ExceptionType.NOT_CORRECT_PASSWORD);
         }
-        String encodePassword=passwordEncoder.encode(updateMyPageRequest.getNewPassword());
+        String encodePassword=passwordEncoder.encode(updateUserInfoRequest.getNewPassword());
         UpdateUserCommand command = UpdateUserCommand.builder()
                 .password(encodePassword)
-                .department(updateMyPageRequest.getDepartment())
-                .grade(updateMyPageRequest.getGrade())
-                .phoneNumber(updateMyPageRequest.getPhoneNumber())
-                .departmentPublic(updateMyPageRequest.getDepartmentPublic())
-                .gradePublic(updateMyPageRequest.getGradePublic())
-                .studentIdPublic(updateMyPageRequest.getStudentIdPublic())
-                .phonePublic(updateMyPageRequest.getPhonePublic())
+                .department(updateUserInfoRequest.getDepartment())
+                .grade(updateUserInfoRequest.getGrade())
+                .phoneNumber(updateUserInfoRequest.getPhoneNumber())
+                .departmentPublic(updateUserInfoRequest.getDepartmentPublic())
+                .gradePublic(updateUserInfoRequest.getGradePublic())
+                .studentIdPublic(updateUserInfoRequest.getStudentIdPublic())
+                .phonePublic(updateUserInfoRequest.getPhonePublic())
                 .build();
         user.updateUserInfo(command);
         userRepository.save(user);


### PR DESCRIPTION


## ✨ PR 요약
- 로그인 시 ROLE 필드 추가
- 마이페이지 회원 도서 현황 조회 기능

## 🔎 작업 상세
- 로그인 응답 dto에 Role 필드를 추가해서 프론트에서 사용자의 역할을 구분하여 라우팅 할 수 있도록 하였습니다.
- myPage 디렉토리를 book,userInfo로 구분하였습니다.
- 마이페이지에서 회원의 대출 현황, 예약 현황, 반납 현황을 개발했습니다. 해당 페이지에서 책 이름을 보여줘야 하는데, Reservation에서는 book.id 필드만 존재하기 때문에 book 도메인에서 tiitle을 조회해야 합니다. 이때 지연 로딩에 의해 N+1문제가 발생할 수 있기 때문에 이를 해결하기 위해 dto 프로덕션을 사용했습니다. JOIN FETCH를 사용하지 않은 이유는 엔티티 전체를 먼저 조회한 후 변환하는 과정이 필요하므로 불필요한 데이터 로딩이 발생한다고 합니다. jpql이 복잡할 때 QueryDSL도 적용해볼 수 있다고 합니다. JPQL보다 가독성이 좋고, 여러 개의 조건이 있거 동적 쿼리에 강하다고 하네요.  또한 N+1문제를 QueryDSL에서는 .fetchJoin()를 통해 쉽게 해결한다고 합니다. 그러나 아직 이 부분에 대한 개념이 부족해서 일단 dto 방식으로 구현했습니다.

