### PR TITLE
Bug:findReservationByBookAndUserId JPQL 수정 #47

### DIFF
--- a/src/main/java/com/club_board/club_board_server/repository/reservation/ReservationRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/reservation/ReservationRepository.java
@@ -26,7 +26,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("SELECT COUNT(r) FROM Reservation r WHERE r.book.id = :bookId AND (r.status='RESERVED' OR r.status='BORROWING')")
     int countActiveReservation(@Param("bookId") Long bookId);
 
-    @Query("SELECT r From Reservation r WHERE r.book.id=:bookId AND r.user.id=:userId")
+    @Query("SELECT r From Reservation r WHERE r.book.id=:bookId AND r.user.id=:userId AND (r.status='RESERVED' OR r.status='BORROWING')")
     Optional<Reservation> findReservationByBookAndUserId(@Param("bookId") Long bookId, @Param("userId") Long userId);
 
     @Query("select new com.club_board.club_board_server.dto.myPage.book.MyLoanResponse(" +


### PR DESCRIPTION
## 🚧연관 이슈
Close #47 

## ✨ PR 요약

- findReservationByBookAndUserId JPQL 수정


## 🔎 작업 상세

- 유저가 이미 책을 대여중인지 확인하는 로직에서 예약,대여중인 도서만 추출하도록 설정