### PR TITLE
refactor: 마이페이지 URI 수정 #52

### DIFF
--- a/src/main/java/com/club_board/club_board_server/controller/mypage/MyLoanController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/mypage/MyLoanController.java
@@ -1,5 +1,6 @@
 package com.club_board.club_board_server.controller.mypage;
 
+import com.club_board.club_board_server.domain.user.CustomUserDetails;
 import com.club_board.club_board_server.dto.myPage.book.MyLoanResponse;
 import com.club_board.club_board_server.dto.myPage.book.MyReservationResponse;
 import com.club_board.club_board_server.dto.myPage.book.MyReturnResponse;
@@ -9,9 +10,8 @@ import com.club_board.club_board_server.service.myPage.MyLoanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.parameters.P;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,24 +23,27 @@ import java.util.List;
 public class MyLoanController {
 
     private final MyLoanService myLoanService;
-    @GetMapping("/loan/{userId}")
-    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<ResponseBody<List<MyLoanResponse>>> getLoanStatus(@PathVariable("userId") @P("userId") Long userId){
+    @GetMapping("/loan")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER','ROLE_ADMIN','ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<List<MyLoanResponse>>> getLoanStatus(@AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long userId=customUserDetails.getUser().getId();
         List<MyLoanResponse> myLoanResponse=myLoanService.getMyLoan(userId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myLoanResponse));
     }
 
-    @GetMapping("/reservation/{userId}")
-    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<ResponseBody<List<MyReservationResponse>>> getReservationStatus(@PathVariable("userId") @P("userId") Long userId){
+    @GetMapping("/reservation")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER','ROLE_ADMIN','ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<List<MyReservationResponse>>> getReservationStatus(@AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long userId=customUserDetails.getUser().getId();
         List<MyReservationResponse> myReservationResponse=myLoanService.getMyReservations(userId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myReservationResponse));
     }
 
-    @GetMapping("/return/{userId}")
-    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<ResponseBody<List<MyReturnResponse>>> getReturnStatus(@PathVariable("userId") @P("userId") Long userId){
-        List<MyReturnResponse> myLoanResponse=myLoanService.getMyReturn(userId);
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myLoanResponse));
+    @GetMapping("/return")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER','ROLE_ADMIN','ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<List<MyReturnResponse>>> getReturnStatus(@AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long userId=customUserDetails.getUser().getId();
+        List<MyReturnResponse> myReturnResponse=myLoanService.getMyReturn(userId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(myReturnResponse));
     }
 }

--- a/src/main/java/com/club_board/club_board_server/controller/mypage/MyPageController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/mypage/MyPageController.java
@@ -1,4 +1,5 @@
 package com.club_board.club_board_server.controller.mypage;
+import com.club_board.club_board_server.domain.user.CustomUserDetails;
 import com.club_board.club_board_server.dto.myPage.userInfo.UserInfoResponse;
 import com.club_board.club_board_server.dto.myPage.userInfo.UpdateUserInfoRequest;
 import com.club_board.club_board_server.response.ResponseBody;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,16 +21,18 @@ public class MyPageController {
 
     private final MyPageService myPageService;
 
-    @GetMapping("/{userId}")
-    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<ResponseBody<UserInfoResponse>> showMyPage(@PathVariable("userId") @P("userId") Long userId){
+    @GetMapping()
+    @PreAuthorize("hasAnyAuthority('ROLE_USER','ROLE_ADMIN','ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<UserInfoResponse>> showMyPage(@AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long userId=customUserDetails.getUser().getId();
         UserInfoResponse userInfoResponse =myPageService.getMyPage(userId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(userInfoResponse));
     }
 
-    @PatchMapping("/{userId}")
-    @PreAuthorize("@tokenProvider.getUserIdFromToken(authentication.getCredentials(), #userId)")
-    public ResponseEntity<ResponseBody<String>> updateMyPage(@PathVariable("userId") @P("userId") Long userId, @RequestBody UpdateUserInfoRequest updateUserInfoRequest){
+    @PatchMapping()
+    @PreAuthorize("hasAnyAuthority('ROLE_USER','ROLE_ADMIN','ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<String>> updateMyPage(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody UpdateUserInfoRequest updateUserInfoRequest){
+        Long userId=customUserDetails.getUser().getId();
         myPageService.updateMyPage(userId, updateUserInfoRequest);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse("유저 정보 업데이트 성공"));
     }


### PR DESCRIPTION
## 🚨 관련 이슈
- closed #52 

## ✨ PR 요약

- 마이페이지 URI 수정

## 🔎 작업 상세

- 마이페이지 컨트롤러 URI 패턴에서 userId 제거
- AuthenticationPrincipal을 이용하여 Access Token에서 userId 추출
- getReturnStatus에서 부적절한 이름의 response dto 수정 (myLoanResponse --> myReturnResponse)
