### PR TITLE
BUG: WebSecurityConfig cors 설정 수정

### DIFF
--- a/src/main/java/com/club_board/club_board_server/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/security/WebSecurityConfig.java
@@ -19,6 +19,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
@@ -39,7 +41,7 @@ public class WebSecurityConfig{
         http
                 .logout(AbstractHttpConfigurer::disable)  // 시큐리티에서 기본적으로 제공하는 로그아웃 무효화
                 .csrf(AbstractHttpConfigurer::disable) //csrf 무시
-                .cors(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .anyRequest().denyAll()


### PR DESCRIPTION
## 🚨관련 이슈
- closed #61 
- 
## ✨ PR 요약

- WebSecurityConfig cors 설정


## 🔎 작업 상세
- 기존에는 cors.disable() 속성으로 모든 cors 요청을 차단했습니다.
- 이렇게 되면 CORS를 비활성화하여 일반적인 API 서버에서는 사용해서는 안된다고 합니다.
- 따라서 올바르게 CorsConfig가 적용될 수 있게 withDefaults 속성을 추가했는데, 한번 테스트 해보면 좋을거 같습니다.
