### PR TITLE
♻️refactor: s3Service 함수 리팩토링

### DIFF
--- a/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
@@ -23,24 +23,25 @@ public class FileController {
     private final S3Service s3Service;
 
     @PostMapping("/upload-url")
-    @PreAuthorize("hasAuthority('ROLE_USER')")
-    public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generateUploadUrl(
+    @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generatePostFileUploadUrl(
             @RequestBody @Valid PresignedUploadUrlRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        PresignedUploadUrlResponse response = s3Service.generateUploadUrl(request, userDetails.getUser().getId());
+        PresignedUploadUrlResponse response = s3Service.generatePostFileUploadUrl(request, userDetails.getUser().getId());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ResponseUtil.createSuccessResponse(response));
     }
 
     @GetMapping("/download-url")
-    public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generateDownloadUrl(@RequestParam Long fileId) {
-        PresignedDownloadUrlResponse response = s3Service.generateDownloadUrl(fileId);
+    @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generatePostFileDownloadUrl(@RequestParam Long fileId) {
+        PresignedDownloadUrlResponse response = s3Service.generatePostFileDownloadUrl(fileId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }
 
     @PostMapping("/bookImage/upload-url")
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN', 'ROLE_OWNER')")
     public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generateBookImageUploadUrl(
             @RequestBody @Valid PresignedUploadUrlRequest request
     ) {
@@ -50,7 +51,7 @@ public class FileController {
     }
 
     @PostMapping("/bookImage/update-url")
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN', 'ROLE_OWNER')")
     public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generateBookImageUpdateUrl(
             @RequestBody @Valid PresignedUploadUrlRequest request,
             @RequestParam Long bookImageId
@@ -60,6 +61,7 @@ public class FileController {
     }
 
     @GetMapping("/bookImage/download-url")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
     public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generateBookImageDownloadUrl(@RequestParam Long bookImageId) {
         PresignedDownloadUrlResponse response = s3Service.generateBookImageDownloadUrl(bookImageId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));

--- a/src/main/java/com/club_board/club_board_server/domain/post/Post.java
+++ b/src/main/java/com/club_board/club_board_server/domain/post/Post.java
@@ -26,7 +26,6 @@ public class Post extends AuditEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User author;
 
-    @OneToMany
-    @JoinColumn(name = "file_id")
+    @OneToMany(mappedBy = "post")
     private List<File> fileNames;
 }

--- a/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
@@ -1,6 +1,5 @@
 package com.club_board.club_board_server.service.file;
 
-
 import com.club_board.club_board_server.domain.book.BookImage;
 import com.club_board.club_board_server.domain.file.File;
 import com.club_board.club_board_server.dto.file.request.PresignedUploadUrlRequest;
@@ -44,72 +43,23 @@ public class S3Service {
     private final static int PUT_REQUEST_DURATION_OF_MINUTES = 60;
     private final static int GET_REQUEST_DURATION_OF_MINUTES = 60;
 
-    public PresignedUploadUrlResponse generateUploadUrl(PresignedUploadUrlRequest request, Long userId) {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+    public PresignedUploadUrlResponse generatePostFileUploadUrl(PresignedUploadUrlRequest request, Long userId) {
+        String objectName = this.generatePostFileName(request.getFileName(), userId);
 
-        try (
-                S3Presigner s3Presigner = S3Presigner.builder()
-                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                        .region(Region.AP_NORTHEAST_2)
-                        .build()
-        ) {
-            String objectName = this.generateFileName(request.getFileName(), userId);
+        String fileUploadUrl = this.generatePutObjectRequestUrl(objectName, request.getContentType());
 
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(objectName)
-                    .contentType(request.getContentType())
-                    .build();
+        File savedFile = fileService.saveFileName(objectName);
 
-            PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
-                    .signatureDuration(Duration.ofMinutes(PUT_REQUEST_DURATION_OF_MINUTES))
-                    .putObjectRequest(putObjectRequest)
-                    .build();
-
-            PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
-
-            File savedFile = fileService.saveFileName(objectName);
-
-            return PresignedUploadUrlResponse.builder()
-                    .url(presignedPutObjectRequest.url().toString())
-                    .fileId(savedFile.getId())
-                    .build();
-        }
+        return PresignedUploadUrlResponse.builder()
+                .url(fileUploadUrl)
+                .fileId(savedFile.getId())
+                .build();
     }
 
-    private String generateFileName(String originFileName, Long userId) {
+    private String generatePostFileName(String originFileName, Long userId) {
         return String.join(
                 "/", "postFiles", userId.toString(), UUID.randomUUID().toString(), originFileName
         );
-    }
-
-    public PresignedDownloadUrlResponse generateDownloadUrl(Long fileId) {
-        String objectName = fileService.getFileName(fileId);
-
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
-
-        try (
-                S3Presigner s3Presigner = S3Presigner.builder()
-                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                        .region(Region.AP_NORTHEAST_2)
-                        .build()
-        ) {
-            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(objectName)
-                    .build();
-
-            GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
-                    .signatureDuration(Duration.ofMinutes(GET_REQUEST_DURATION_OF_MINUTES))
-                    .getObjectRequest(getObjectRequest)
-                    .build();
-
-            PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
-
-            return PresignedDownloadUrlResponse.builder()
-                    .url(presignedGetObjectRequest.url().toString())
-                    .build();
-        }
     }
 
     public PresignedUploadUrlResponse generateBookImageUploadUrl(PresignedUploadUrlRequest request) {
@@ -117,36 +67,16 @@ public class S3Service {
             throw new BusinessException(ExceptionType.INVALID_FILE_TYPE);
         }
 
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        String objectName = this.generateBookImageName(request.getFileName());
 
-        try (
-                S3Presigner s3Presigner = S3Presigner.builder()
-                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                        .region(Region.AP_NORTHEAST_2)
-                        .build()
-        ) {
-            String objectName = this.generateBookImageName(request.getFileName());
+        String fileUploadUrl = this.generatePutObjectRequestUrl(objectName, request.getContentType());
 
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(objectName)
-                    .contentType(request.getContentType())
-                    .build();
+        BookImage savedBookImage = bookImageService.saveBookImage(objectName);
 
-            PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
-                    .signatureDuration(Duration.ofMinutes(PUT_REQUEST_DURATION_OF_MINUTES))
-                    .putObjectRequest(putObjectRequest)
-                    .build();
-
-            PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
-
-            BookImage savedBookImage = bookImageService.saveBookImage(objectName);
-
-            return PresignedUploadUrlResponse.builder()
-                    .url(presignedPutObjectRequest.url().toString())
-                    .fileId(savedBookImage.getId())
-                    .build();
-        }
+        return PresignedUploadUrlResponse.builder()
+                .url(fileUploadUrl)
+                .fileId(savedBookImage.getId())
+                .build();
     }
 
     private String generateBookImageName(String originFileName) {
@@ -155,11 +85,7 @@ public class S3Service {
         );
     }
 
-    public PresignedUploadUrlResponse generateBookImageUpdateUrl(PresignedUploadUrlRequest request, Long bookImageId) {
-        if (!request.getContentType().startsWith("image/")) {
-            throw new BusinessException(ExceptionType.INVALID_FILE_TYPE);
-        }
-
+    private String generatePutObjectRequestUrl(String objectName, String contentType) {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         try (
@@ -168,12 +94,10 @@ public class S3Service {
                         .region(Region.AP_NORTHEAST_2)
                         .build()
         ) {
-            String objectName = bookImageService.getFileName(bookImageId);
-
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(objectName)
-                    .contentType(request.getContentType())
+                    .contentType(contentType)
                     .build();
 
             PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
@@ -183,16 +107,31 @@ public class S3Service {
 
             PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
 
-            return PresignedUploadUrlResponse.builder()
-                    .url(presignedPutObjectRequest.url().toString())
-                    .fileId(bookImageId)
-                    .build();
+            return presignedPutObjectRequest.url().toString();
         }
+    }
+
+    public PresignedDownloadUrlResponse generatePostFileDownloadUrl(Long fileId) {
+        String objectName = fileService.getFileName(fileId);
+
+        String fileDownloadUrl = this.generateGetObjectRequestUrl(objectName);
+
+        return PresignedDownloadUrlResponse.builder()
+                .url(fileDownloadUrl)
+                .build();
     }
 
     public PresignedDownloadUrlResponse generateBookImageDownloadUrl(Long bookImageId) {
         String objectName = bookImageService.getFileName(bookImageId);
 
+        String fileDownloadUrl = this.generateGetObjectRequestUrl(objectName);
+
+        return PresignedDownloadUrlResponse.builder()
+                .url(fileDownloadUrl)
+                .build();
+    }
+
+    private String generateGetObjectRequestUrl(String objectName) {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         try (
@@ -213,17 +152,30 @@ public class S3Service {
 
             PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
 
-            return PresignedDownloadUrlResponse.builder()
-                    .url(presignedGetObjectRequest.url().toString())
-                    .build();
+            return presignedGetObjectRequest.url().toString();
         }
     }
 
-    public void deleteBookImage(BookImage bookImage) {
-        this.deleteObject(bookImage.getUrl());
+    public PresignedUploadUrlResponse generateBookImageUpdateUrl(PresignedUploadUrlRequest request, Long bookImageId) {
+        if (!request.getContentType().startsWith("image/")) {
+            throw new BusinessException(ExceptionType.INVALID_FILE_TYPE);
+        }
+
+        String objectName = bookImageService.getFileName(bookImageId);
+
+        String fileUpdateUrl = this.generatePutObjectRequestUrl(objectName, request.getContentType());
+
+        return PresignedUploadUrlResponse.builder()
+                .url(fileUpdateUrl)
+                .fileId(bookImageId)
+                .build();
     }
 
-    private void deleteObject(String url) {
+    public void deleteBookImage(BookImage bookImage) {
+        this.deleteObjectRequest(bookImage.getUrl());
+    }
+
+    private void deleteObjectRequest(String url) {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         try (


### PR DESCRIPTION
<!-- 주석은 삭제하고 사용하시면 됩니다! -->

## 🚨관련 이슈
- closed #65 

## ✨ PR 요약
- `s3Service` 함수 리팩토링

## 🔎 작업 상세

- `s3Service` 함수 리팩토링
  - `generatePutObjectRequestUrl` 함수로 `PresignedPutObjectRequest` 사용한 생성 및 수정 관련 presigned-url 발급 로직 분리
  - `generateGetObjectRequestUrl` 함수로 `PresignedGetObjectRequest` 사용한 조회 관련 presigned-url 발급 로직 분리
  - 함수명 명확히 변경(`generateUploadUrl` -> `generatePostFileUploadUrl` 처럼 Post의 File임을 명시)
- fileController에 인가 ROLE 추가
  - `ROLE_OWNER` 추가
  - 다운로드 로직에 `ROLE_USER` 이상 인가되도록 변경
- File 엔티티 제약 조건 관련 버그 해결(nullable 인데도 계속 제약 조건이 생기는 현상)
  - Post 엔티티에 `mappedBy` 추가로 해결
