### PR TITLE
BUG:책 예약 시 상태 업데이트 오류 수정 #69

### DIFF
--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -110,14 +110,19 @@ public class BookService {
         reservationRepository.save(reservation);
 
         int nextReservationCount=currentReservationCount+1;
-        if(nextReservationCount>=1 && nextReservationCount<MAX_RESERVATION_COUNT){
-            book.setStatus(BookStatus.RESERVED);
+        BookStatus targetStatus = book.getStatus();
+
+        if (nextReservationCount >= MAX_RESERVATION_COUNT) {
+            targetStatus = BookStatus.FULLY_RESERVED;
+        } else if (nextReservationCount > 0) {
+            targetStatus = BookStatus.RESERVED;
         }
-        // 예약 수가 3명이 되면 책 상태를 FULLY_RESERVED로 변경
-        else if(nextReservationCount >= MAX_RESERVATION_COUNT) {
-            book.setStatus(BookStatus.FULLY_RESERVED);
+
+        // 현재 상태와 다를 때만 상태를 업데이트
+        if (book.getStatus() != targetStatus) {
+            book.setStatus(targetStatus);
+            bookRepository.save(book);
         }
-        bookRepository.save(book);
     }
 
     // 예약 취소

--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -29,7 +29,7 @@ public class BookService {
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final S3Service s3Service;
-
+    private static final int MAX_RESERVATION_COUNT=3;
 
     // 모든 책을 조회, 데이터가 많아질 시 추후 페이징 처리 필요해보임
     public List<BookResponse> getAllBooks(Long userId){
@@ -91,7 +91,7 @@ public class BookService {
 
         // 예약 수를 동적으로 계산하여 체크
         int currentReservationCount = reservationRepository.countActiveReservation(book.getId());
-        if (currentReservationCount >= 3 || book.getStatus()==BookStatus.FULLY_RESERVED) {
+        if (currentReservationCount >= MAX_RESERVATION_COUNT || book.getStatus()==BookStatus.FULLY_RESERVED) {
             throw new BusinessException(ExceptionType.BOOK_ALREADY_FULL);
         }
 
@@ -109,11 +109,15 @@ public class BookService {
         Reservation reservation=new Reservation(user,book);
         reservationRepository.save(reservation);
 
-        // 예약 수가 3명이 되면 책 상태를 FULLY_RESERVED로 변경
-        if (currentReservationCount + 1 >= 3) {
-            book.setStatus(BookStatus.FULLY_RESERVED);
-            bookRepository.save(book);
+        int nextReservationCount=currentReservationCount+1;
+        if(nextReservationCount>=1 && nextReservationCount<MAX_RESERVATION_COUNT){
+            book.setStatus(BookStatus.RESERVED);
         }
+        // 예약 수가 3명이 되면 책 상태를 FULLY_RESERVED로 변경
+        else if(nextReservationCount >= MAX_RESERVATION_COUNT) {
+            book.setStatus(BookStatus.FULLY_RESERVED);
+        }
+        bookRepository.save(book);
     }
 
     // 예약 취소
@@ -125,7 +129,13 @@ public class BookService {
                 .orElseThrow(()->new BusinessException(ExceptionType.RESERVATION_NOT_FOUND));
         reservationRepository.delete(reservation);
 
-        if (book.getStatus() == BookStatus.FULLY_RESERVED && reservationRepository.countActiveReservation(book.getId())-1<3) {
+        int currentReservationCount = reservationRepository.countActiveReservation(book.getId());
+        // 예약 취소시 인원수가 1부터 2이하 --> 책 RESERVED
+        if (book.getStatus()==BookStatus.FULLY_RESERVED && currentReservationCount>=1 && currentReservationCount<MAX_RESERVATION_COUNT) {
+            book.setStatus(BookStatus.RESERVED);
+        }
+        // 인원수가 0이다 --> 책 AVAILABLE
+        else if(book.getStatus() == BookStatus.RESERVED && currentReservationCount==0) {
             book.setStatus(BookStatus.AVAILABLE);
         }
     }

--- a/src/main/java/com/club_board/club_board_server/service/book/BookService.java
+++ b/src/main/java/com/club_board/club_board_server/service/book/BookService.java
@@ -136,11 +136,11 @@ public class BookService {
 
         int currentReservationCount = reservationRepository.countActiveReservation(book.getId());
         // 예약 취소시 인원수가 1부터 2이하 --> 책 RESERVED
-        if (book.getStatus()==BookStatus.FULLY_RESERVED && currentReservationCount>=1 && currentReservationCount<MAX_RESERVATION_COUNT) {
+        if (currentReservationCount>=1 && currentReservationCount<MAX_RESERVATION_COUNT) {
             book.setStatus(BookStatus.RESERVED);
         }
         // 인원수가 0이다 --> 책 AVAILABLE
-        else if(book.getStatus() == BookStatus.RESERVED && currentReservationCount==0) {
+        else if(currentReservationCount==0) {
             book.setStatus(BookStatus.AVAILABLE);
         }
     }


### PR DESCRIPTION
## 🚨관련 이슈
- closed #69 

## ✨ PR 요약
- 책 상태 업데이트 로직 추가
- 최대 예약 인원 상수로 따로 관리

## 🔎 작업 상세
- `addReservation` 로직에서 `BookStatus`를 관리하는 로직에 오류가 있었습니다. 예약 추가 시 `Reservation` 엔티티의 상태만 변경하고 `BookStatus`를 관리하는 로직은 없었습니다.
- 따라서 `currentReservationCount`와 `if-else`문을 사용하여 책 상태 로직을 추가하였습니다.
- `MAX_RESERVATION_COUNT` 상수로 최대 예약 인원을 관리할 수 있도록 수정했습니다. 추후 최대 예약 인원이 변경될 수 있으므로, 이를 쉽게 유지보수할 수 있도록 했습니다.
