### PR TITLE
✨feat: 프로필 사진 수정, 다운로드, 삭제 기능 추가

### DIFF
--- a/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
@@ -1,8 +1,10 @@
 package com.club_board.club_board_server.controller.file;
 
 import com.club_board.club_board_server.domain.user.CustomUserDetails;
+import com.club_board.club_board_server.dto.file.request.PresignedProfileImageUrlRequest;
 import com.club_board.club_board_server.dto.file.request.PresignedUploadUrlRequest;
 import com.club_board.club_board_server.dto.file.response.PresignedDownloadUrlResponse;
+import com.club_board.club_board_server.dto.file.response.PresignedProfileImageUrlResponse;
 import com.club_board.club_board_server.dto.file.response.PresignedUploadUrlResponse;
 import com.club_board.club_board_server.response.ResponseBody;
 import com.club_board.club_board_server.response.ResponseUtil;
@@ -67,4 +69,31 @@ public class FileController {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }
 
+    @PostMapping("/profileImage/update-url")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<PresignedProfileImageUrlResponse>> generateProfileImageUpdateUrl(
+            @RequestBody @Valid PresignedProfileImageUrlRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        PresignedProfileImageUrlResponse response = s3Service.generateProfileImageUpdateUrl(request, userDetails.getUser().getId());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
+    }
+
+    @GetMapping("/profileImage/download-url")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generateProfileImageDownloadUrl(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        PresignedDownloadUrlResponse response = s3Service.generateProfileImageDownloadUrl(userDetails.getUser().getId());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
+    }
+
+    @DeleteMapping("/profileImage")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
+    public ResponseEntity<ResponseBody<Void>> deleteProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        s3Service.deleteProfileImage(userDetails.getUser().getId());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
 }

--- a/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
+++ b/src/main/java/com/club_board/club_board_server/controller/file/FileController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class FileController {
     private final S3Service s3Service;
 
-    @PostMapping("/upload-url")
+    @PostMapping("/postFile/upload-url")
     @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
     public ResponseEntity<ResponseBody<PresignedUploadUrlResponse>> generatePostFileUploadUrl(
             @RequestBody @Valid PresignedUploadUrlRequest request,
@@ -33,7 +33,7 @@ public class FileController {
                 .body(ResponseUtil.createSuccessResponse(response));
     }
 
-    @GetMapping("/download-url")
+    @GetMapping("/postFile/download-url")
     @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN', 'ROLE_OWNER')")
     public ResponseEntity<ResponseBody<PresignedDownloadUrlResponse>> generatePostFileDownloadUrl(@RequestParam Long fileId) {
         PresignedDownloadUrlResponse response = s3Service.generatePostFileDownloadUrl(fileId);

--- a/src/main/java/com/club_board/club_board_server/domain/user/User.java
+++ b/src/main/java/com/club_board/club_board_server/domain/user/User.java
@@ -46,6 +46,9 @@ public class User {
     private LocalDate lastLoginDate;
 
     @Setter
+    private String profileImageUrl;
+
+    @Setter
     private boolean isOverdue;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/ExceptionType.java
@@ -13,6 +13,7 @@ public enum ExceptionType {
     BINDING_ERROR(BAD_REQUEST,"C002","바인딩시 에러 발생"),
     ESSENTIAL_FIELD_MISSING_ERROR(BAD_REQUEST , "C003","필수적인 필드 부재"),
     INVALID_JSON_FORMAT(BAD_REQUEST, "C004", "잘못된 JSON 데이터 형식"),
+    NOT_SUPPORTED_METHOD(METHOD_NOT_ALLOWED, "C005", "허용되지 않은 http method 접근"),
 
 
     //User

--- a/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/club_board/club_board_server/response/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -70,9 +71,16 @@ public class GlobalExceptionHandler {
                 .body(ResponseUtil.createFailureResponse(ExceptionType.INVALID_JSON_FORMAT));
     }
 
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ResponseBody<Void>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity
+                .status(ExceptionType.NOT_SUPPORTED_METHOD.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.NOT_SUPPORTED_METHOD));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseBody<Void>> exception(Exception e){
-        e.printStackTrace();
+        log.error(e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ResponseUtil.createFailureResponse(ExceptionType.UNEXPECTED_SERVER_ERROR));

--- a/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
@@ -2,12 +2,15 @@ package com.club_board.club_board_server.service.file;
 
 import com.club_board.club_board_server.domain.book.BookImage;
 import com.club_board.club_board_server.domain.file.File;
+import com.club_board.club_board_server.dto.file.request.PresignedProfileImageUrlRequest;
 import com.club_board.club_board_server.dto.file.request.PresignedUploadUrlRequest;
 import com.club_board.club_board_server.dto.file.response.PresignedDownloadUrlResponse;
+import com.club_board.club_board_server.dto.file.response.PresignedProfileImageUrlResponse;
 import com.club_board.club_board_server.dto.file.response.PresignedUploadUrlResponse;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
 import com.club_board.club_board_server.service.book.BookImageService;
+import com.club_board.club_board_server.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -30,6 +33,7 @@ import java.util.UUID;
 public class S3Service {
     private final FileService fileService;
     private final BookImageService bookImageService;
+    private final UserService userService;
 
     @Value("${aws.s3.credentials.accessKey}")
     private String accessKey;
@@ -129,6 +133,20 @@ public class S3Service {
                 .build();
     }
 
+    public PresignedDownloadUrlResponse generateProfileImageDownloadUrl(Long userId) {
+        String objectName = this.getProfileImageName(userId);
+
+        String fileDownloadUrl = this.generateGetObjectRequestUrl(objectName);
+
+        return PresignedDownloadUrlResponse.builder()
+                .url(fileDownloadUrl)
+                .build();
+    }
+
+    private String getProfileImageName(Long userId) {
+        return userService.getProfileImageUrl(userId);
+    }
+
     private String generateGetObjectRequestUrl(String objectName) {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
@@ -154,6 +172,24 @@ public class S3Service {
         }
     }
 
+    public PresignedProfileImageUrlResponse generateProfileImageUpdateUrl(PresignedProfileImageUrlRequest request, Long userId) {
+        this.checkImageContentType(request.getContentType());
+
+        String objectName = this.generateProfileImageName(userId);
+
+        String fileUploadUrl = this.generatePutObjectRequestUrl(objectName, request.getContentType());
+
+        userService.setProfileImageUrl(userId, objectName);
+
+        return PresignedProfileImageUrlResponse.builder()
+                .url(fileUploadUrl)
+                .build();
+    }
+
+    private String generateProfileImageName(Long userId) {
+        return String.join("/", "profileImages", userId.toString(), UUID.randomUUID().toString());
+    }
+
     public PresignedUploadUrlResponse generateBookImageUpdateUrl(PresignedUploadUrlRequest request, Long bookImageId) {
         this.checkImageContentType(request.getContentType());
 
@@ -175,6 +211,12 @@ public class S3Service {
 
     public void deleteBookImage(BookImage bookImage) {
         this.deleteObjectRequest(bookImage.getUrl());
+    }
+
+    public void deleteProfileImage(Long userId) {
+        this.deleteObjectRequest(this.getProfileImageName(userId));
+
+        userService.setProfileImageUrl(userId, null);
     }
 
     private void deleteObjectRequest(String url) {

--- a/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
@@ -179,6 +179,12 @@ public class S3Service {
 
         String fileUploadUrl = this.generatePutObjectRequestUrl(objectName, request.getContentType());
 
+        String preProfileImageUrl = userService.getProfileImageUrl(userId);
+
+        if (preProfileImageUrl != null) {
+            deleteProfileImage(userId);
+        }
+
         userService.setProfileImageUrl(userId, objectName);
 
         return PresignedProfileImageUrlResponse.builder()

--- a/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
+++ b/src/main/java/com/club_board/club_board_server/service/file/S3Service.java
@@ -63,9 +63,7 @@ public class S3Service {
     }
 
     public PresignedUploadUrlResponse generateBookImageUploadUrl(PresignedUploadUrlRequest request) {
-        if (!request.getContentType().startsWith("image/")) {
-            throw new BusinessException(ExceptionType.INVALID_FILE_TYPE);
-        }
+        this.checkImageContentType(request.getContentType());
 
         String objectName = this.generateBookImageName(request.getFileName());
 
@@ -157,9 +155,7 @@ public class S3Service {
     }
 
     public PresignedUploadUrlResponse generateBookImageUpdateUrl(PresignedUploadUrlRequest request, Long bookImageId) {
-        if (!request.getContentType().startsWith("image/")) {
-            throw new BusinessException(ExceptionType.INVALID_FILE_TYPE);
-        }
+        this.checkImageContentType(request.getContentType());
 
         String objectName = bookImageService.getFileName(bookImageId);
 
@@ -169,6 +165,12 @@ public class S3Service {
                 .url(fileUpdateUrl)
                 .fileId(bookImageId)
                 .build();
+    }
+
+    private void checkImageContentType(String contentType) {
+        if (!contentType.startsWith("image/")) {
+            throw new BusinessException(ExceptionType.INVALID_FILE_TYPE);
+        }
     }
 
     public void deleteBookImage(BookImage bookImage) {
@@ -192,5 +194,4 @@ public class S3Service {
             s3.deleteObject(deleteObjectsRequest);
         }
     }
-
 }

--- a/src/main/java/com/club_board/club_board_server/service/user/UserService.java
+++ b/src/main/java/com/club_board/club_board_server/service/user/UserService.java
@@ -14,9 +14,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,5 +108,20 @@ public class UserService {
 
     private boolean isValidCode(VerificationCode verificationCode,MailVerifyRequest mailVerifyRequest) { //코드 일치 체크
         return verificationCode.getCode() == mailVerifyRequest.getMailCode();
+    }
+
+    @Transactional
+    public void setProfileImageUrl(Long userId, String objectName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        user.setProfileImageUrl(objectName);
+    }
+
+    public String getProfileImageUrl(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        return user.getProfileImageUrl();
     }
 }


### PR DESCRIPTION
<!-- 주석은 삭제하고 사용하시면 됩니다! -->
## 🚨관련 이슈
- closed #66 


## ✨ PR 요약

- 프로필 사진 수정, 다운로드, 삭제 기능 추가


## 🔎 작업 상세

- 프로필 사진 수정, 다운로드, 삭제 기능 추가
  - 도서 이미지 로직과 비슷한 s3 로직으로 구성
  - `User` 엔티티에 `profileImageUrl` 필드 추가
- `contentType`이 `image`인지 검증하는 함수 분리
- 지원하지 않는 http 메서드에 대한 예외 처리 handler 추가