### PR TITLE
:bug:fix: 대출 중 데이터 조회 시 잘못된 데이터 수정

### DIFF
--- a/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyLoanResponse.java
+++ b/src/main/java/com/club_board/club_board_server/dto/myPage/book/MyLoanResponse.java
@@ -1,14 +1,27 @@
 package com.club_board.club_board_server.dto.myPage.book;
-import lombok.AllArgsConstructor;
+
 import lombok.Getter;
 import java.time.LocalDateTime;
 
+import static com.club_board.club_board_server.service.book.BookAdminService.MAX_LOAN_PERIOD_DAYS;
+
 @Getter
-@AllArgsConstructor
 public class MyLoanResponse {
     private Long bookId;
     private String bookName;
     private LocalDateTime loanDate;
     private LocalDateTime returnDate;
     private Integer overdueDate;
+
+    public MyLoanResponse(Long bookId, String bookName, LocalDateTime loanDate, Integer overdueDate) {
+        this.bookId = bookId;
+        this.bookName = bookName;
+        this.loanDate = loanDate;
+        this.returnDate = loanDate.plusDays(MAX_LOAN_PERIOD_DAYS);
+        if (overdueDate < 0) {
+            this.overdueDate = 0;
+        } else {
+            this.overdueDate = overdueDate;
+        }
+    }
 }

--- a/src/main/java/com/club_board/club_board_server/repository/reservation/ReservationRepository.java
+++ b/src/main/java/com/club_board/club_board_server/repository/reservation/ReservationRepository.java
@@ -33,7 +33,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     Optional<Reservation> findBorrowedReservationByBookAndUser(@Param("bookId") Long bookId, @Param("userId") Long userId);
 
     @Query("select new com.club_board.club_board_server.dto.myPage.book.MyLoanResponse(" +
-            "b.id, b.title, r.borrowDate, r.returnDate, " +
+            "b.id, b.title, r.borrowDate, " +
             "CAST(function('DATEDIFF', current_date, function('ADDDATE', r.borrowDate, 14)) AS int)) " +
             "from Reservation r join r.book b " +
             "where r.user.id = :userId and (r.status = 'BORROWING' or r.status = 'OVERDUE')")


### PR DESCRIPTION

## ✨ PR 요약

- 대출 중 데이터 조회 시 잘못된 데이터 수정


## 🔎 작업 상세

- dto 생성자를 수정하여 해결
  - `returnDate`는 `loanDate`에 대출 기간(14일)만큼 `plusDays` 함수 사용
  - `overdueDate`는 0 이하일 경우 0을 반환하도록 변경
