### PR TITLE
[BUG] 액세스 토큰 재발급 오류

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD to EC2
 
 on:
   push:
-    branches: [ "dev", "ci-cd", "cors", "AccessToken" ]
+    branches: [ "dev", "ci-cd", "cors"]
 
 jobs:
   build-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD to EC2
 
 on:
   push:
-    branches: [ "dev", "ci-cd", "cors"]
+    branches: [ "dev", "ci-cd", "cors" ]
 
 jobs:
   build-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD to EC2
 
 on:
   push:
-    branches: [ "dev", "ci-cd", "cors" ]
+    branches: [ "dev", "ci-cd", "cors", "AccessToken" ]
 
 jobs:
   build-deploy:

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
@@ -6,6 +6,7 @@ import com.club_board.club_board_server.service.auth.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,10 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("토큰 검사 시작");
         String accessToken = getAccessToken(request);
         // 토큰이 존재할 때
+        log.info("검사 결과={}",accessToken);
         if (accessToken != null) {
             // 토큰 유효성 검사
             tokenProvider.validToken(accessToken,TokenType.ACCESS);
@@ -55,11 +58,14 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String getAccessToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
-            return bearerToken.substring(TOKEN_PREFIX.length());
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("access-token".equals(cookie.getName())) {
+                    log.info("access token={}", cookie.getValue());
+                    return cookie.getValue();
+                }
+            }
         }
         return null;
     }
-
 }

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         log.info("검사 결과={}",accessToken);
         if (accessToken != null) {
             // 토큰 유효성 검사
-            tokenProvider.validToken(accessToken,TokenType.ACCESS);
+            tokenProvider.validToken(accessToken,TokenType.ACCESS,response);
             authenticateWithToken(accessToken);
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.club_board.club_board_server.config.jwt;
 
-import com.club_board.club_board_server.response.exception.BusinessException;
-import com.club_board.club_board_server.response.exception.ExceptionType;
 import com.club_board.club_board_server.service.auth.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -31,10 +29,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info("토큰 검사 시작");
         String accessToken = getAccessToken(request);
         // 토큰이 존재할 때
-        log.info("검사 결과={}",accessToken);
         if (accessToken != null) {
             // 토큰 유효성 검사
             tokenProvider.validToken(accessToken,TokenType.ACCESS,response);
@@ -61,7 +57,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
                 if ("access-token".equals(cookie.getName())) {
-                    log.info("access token={}", cookie.getValue());
                     return cookie.getValue();
                 }
             }

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenExceptionHandlerFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenExceptionHandlerFilter.java
@@ -34,15 +34,18 @@ public class TokenExceptionHandlerFilter extends OncePerRequestFilter { // OnceP
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8"); // HttpServletResponse: ISO-8859-1 인코딩 사용하기 때문에 한글 출력을 위해 UTF-8 설정
 
-        // CORS 관련 헤더를 명시적으로 추가
-        response.setHeader("Access-Control-Allow-Origin", "*");
+        String origin = request.getHeader("Origin");
+        if(origin == null || origin.isEmpty()){
+            origin = "https://chipsatbooks.vercel.app";
+        }
+        response.setHeader("Access-Control-Allow-Origin", origin);
         response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
         response.setHeader("Vary", "Origin, Access-Control-Request-Method, Access-Control-Request-Headers");
         
         ResponseBody<Void> body= ResponseUtil.createFailureResponse(exceptionType);
         writeErrorResponse(response,body);
-
     }
     private void writeErrorResponse(HttpServletResponse response, ResponseBody<Void> body) throws IOException{
         ObjectMapper objectMapper = new ObjectMapper(); // Jackson ObjectMapper 인스턴스 생성

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenExceptionHandlerFilter.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenExceptionHandlerFilter.java
@@ -1,4 +1,5 @@
 package com.club_board.club_board_server.config.jwt;
+
 import com.club_board.club_board_server.response.ResponseBody;
 import com.club_board.club_board_server.response.ResponseUtil;
 import com.club_board.club_board_server.response.exception.BusinessException;
@@ -13,7 +14,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.io.PrintWriter;
-
 
 @Component
 public class TokenExceptionHandlerFilter extends OncePerRequestFilter { // OncePerRequestFilter : 한 요청당 필터가 딱 한 번만 실행되도록 보장하는 추상 클래스

--- a/src/main/java/com/club_board/club_board_server/config/jwt/TokenProvider.java
+++ b/src/main/java/com/club_board/club_board_server/config/jwt/TokenProvider.java
@@ -5,8 +5,10 @@ import com.club_board.club_board_server.repository.refreshToken.RefreshTokenRepo
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
 import io.jsonwebtoken.*;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.spec.SecretKeySpec;
@@ -58,7 +60,7 @@ public class TokenProvider {
         }
     }
 
-    public void validToken(String token,TokenType tokenType) {
+    public void validToken(String token, TokenType tokenType, HttpServletResponse response) {
         try {
 
             // SecretKeySpec을 사용하여 Key 객체 생성
@@ -74,6 +76,7 @@ public class TokenProvider {
                     .getBody();
         } catch (ExpiredJwtException e) { // 토큰이 만료되었을 때
             if(tokenType==TokenType.ACCESS){
+                clearAccessTokenCookie(response);
                 throw new BusinessException(ExceptionType.EXPIRED_ACCESS_TOKEN);
             }
             else {
@@ -112,4 +115,31 @@ public class TokenProvider {
 
         refreshTokenRepository.save(refreshTokenEntity);
     }
+    /*
+Access-Token 쿠키 삭제
+*/
+    public void clearAccessTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("access-token", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+    /*
+    Refresh-Token 쿠키 삭제
+     */
+    public void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("refresh-token", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
 }
+

--- a/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
@@ -9,7 +9,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app/")
+                .allowedOriginPatterns("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app/","https://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
@@ -9,7 +9,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app","https://localhost:3000")
+                .allowedOrigins("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app","https://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
@@ -9,7 +9,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app/","https://localhost:3000")
+                .allowedOriginPatterns("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app","https://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
+++ b/src/main/java/com/club_board/club_board_server/config/security/CorsConfig.java
@@ -9,7 +9,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app","https://localhost:3000")
+                .allowedOrigins("http://localhost:5173", "http://localhost:5174", "http://localhost:3000", "https://chipsatbooks.vercel.app", "https://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
+++ b/src/main/java/com/club_board/club_board_server/service/auth/AuthService.java
@@ -3,7 +3,6 @@ import com.club_board.club_board_server.config.jwt.TokenProvider;
 import com.club_board.club_board_server.config.jwt.TokenType;
 import com.club_board.club_board_server.domain.RefreshToken;
 import com.club_board.club_board_server.domain.user.CustomUserDetails;
-import com.club_board.club_board_server.domain.user.Department;
 import com.club_board.club_board_server.domain.user.User;
 import com.club_board.club_board_server.dto.auth.ResetPasswordRequest;
 import com.club_board.club_board_server.dto.auth.UserLoginRequest;
@@ -13,7 +12,6 @@ import com.club_board.club_board_server.repository.user.UserRepository;
 import com.club_board.club_board_server.response.exception.BusinessException;
 import com.club_board.club_board_server.response.exception.ExceptionType;
 import com.club_board.club_board_server.service.mail.EmailService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
@@ -90,10 +88,8 @@ public class AuthService {
     public void logout(String refreshToken, HttpServletResponse response){
         refreshTokenRepository.findByRefreshToken(refreshToken)
                 .ifPresent(refreshTokenRepository::delete);
-        Cookie cookie = new Cookie("refresh-token",null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        response.addCookie(cookie);
+        tokenProvider.clearAccessTokenCookie(response);
+        tokenProvider.clearRefreshTokenCookie(response);
     }
 
     /*
@@ -157,7 +153,7 @@ public class AuthService {
             throw new BusinessException(ExceptionType.AUTHORIZATION_DENIED);
         }
         // Refresh Token 유효성 검사
-        tokenProvider.validToken(refreshToken, TokenType.REFRESH);
+        tokenProvider.validToken(refreshToken, TokenType.REFRESH, response);
 
         // 토큰에서 유저 ID 추출 및 유저 조회
         Long userId = tokenProvider.getClaims(refreshToken).get("id", Long.class);
@@ -194,7 +190,7 @@ public class AuthService {
                 .httpOnly(true)
                 .secure(true)          // 운영 환경에서는 HTTPS 사용 시 true, 개발 환경에서는 false로 설정 가능
                 .path("/")
-                .maxAge(60*60*7)
+                .maxAge(60*60*24*7)
                 .sameSite("None")      // SameSite를 None으로 설정
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());


### PR DESCRIPTION
## 🚨관련 이슈
- closed #81 

## ✨ PR 요약
- 토큰 만료 시 쿠키 삭제 로직 추가
- `Access-Control-Allow-Origin`에 명시적 Origin 설정
- CORS 설정에서 allowedOriginPatterns → allowedOrigins 변경




## 🔎 작업 상세
- 커스텀 토큰 예외 필터에서 Access-Control-Allow-Origin에 명시적으로 헤더를 추가했습니다. 쿠키를 포함한 요청에서 헤더에 와일드카드가 있으면 응답 본문이 제대로 전송되지 않습니다. 따라서 request 객체에서 Origin 헤더를 추출하여 명시적으로 응답 헤더를 설정했습니다.

<와일드 카드 적용 시 Body가 안담기는 모습>
![image](https://github.com/user-attachments/assets/910ddf70-815c-4c9b-878c-bd41b3b73cba)

- getAccessToken 메소드 : 기존에는 액세스 토큰을 헤더에 담아서 보냈기 때문에 헤더에서 추출했으나, 현재는 쿠키에 담아서 전송하기 때문에 쿠키에서 추출하는 로직으로 변경했습니다.
- 액세스 토큰이 만료되면 액세스 토큰을 쿠키에서 삭제하도록 설정했습니다. 
- 쿠키를 포함한 요청에서는 CORS 정책이 더 민감하게 동작합니다. `allowedOriginPatterns`는 패턴이므로 브라우저가 와일드카드로 인식할 여지가 있어 정확한 Origin을 명시하는 allowedOrigins로 변경했습니다.


